### PR TITLE
feat: add `includes` connective and `remove` verb

### DIFF
--- a/src/liminate/analyzer.py
+++ b/src/liminate/analyzer.py
@@ -67,6 +67,7 @@ from .parser import (
     NameRef,
     NumberLiteral,
     PackVerbNode,
+    RemoveNode,
     QuotedString,
     RememberCompositionNode,
     RememberListNode,
@@ -300,6 +301,11 @@ def _check(
             node, symtab, iterator,
             live_value_names=live_value_names,
         )
+    elif isinstance(node, RemoveNode):
+        _check_remove(
+            node, symtab, iterator,
+            live_value_names=live_value_names,
+        )
     elif isinstance(node, FinishNode):
         # v3a §112: `finish` is legal only inside a `when` action block
         # (directly, in a `choose` branch, or in a composition called
@@ -451,6 +457,9 @@ def _side_effect_verb(
     if isinstance(node, AddNode):
         # Liminate `add` v1 §5 — silent mutation; returns no value.
         return "add"
+    if isinstance(node, RemoveNode):
+        # `remove` — silent mutation; returns no value.
+        return "remove"
     if isinstance(node, (RememberListNode, RememberRecordNode, RememberCompositionNode)):
         return "remember"
     if isinstance(node, RememberValueNode):
@@ -743,6 +752,8 @@ def _check_condition(
         return
     if cond.op == "equal_to":
         return  # any same-type comparison; analyzer doesn't enforce
+    if cond.op in ("includes", "not_includes"):
+        return  # list-membership — analyzer accepts any operand types
     if cond.op.startswith("not_"):
         inner = cond.op[len("not_"):]
         if inner in ("above", "below"):
@@ -1057,6 +1068,8 @@ def _check_choose_condition(
         _require_numeric(field_type, field_label, cond.op)
         _require_numeric(value_type, value_label, cond.op)
         return
+    if cond.op in ("includes", "not_includes"):
+        return
     if cond.op.startswith("not_"):
         inner = cond.op[len("not_"):]
         if inner in ("above", "below"):
@@ -1339,6 +1352,28 @@ def _check_add(
     )
 
 
+def _check_remove(
+    node: RemoveNode,
+    symtab: dict[str, SymbolEntry],
+    iterator: IteratorContext | None,
+    *,
+    live_value_names: set[str] | None = None,
+) -> None:
+    """`remove` verb validation — same shape as `_check_add`.
+
+    Reuses `_check_list_append`: live-value restriction, target exists
+    and is a list, item resolves to a value, self-mutation guard inside
+    `each`. The element-category match is also enforced — removing a
+    number from a list of strings is a static error regardless of
+    runtime contents.
+    """
+    _check_list_append(
+        node.target.name, node.item, symtab, iterator,
+        live_value_names=live_value_names,
+        verb="remove",
+    )
+
+
 def _check_list_append(
     target_name: str,
     item_node: ASTNode,
@@ -1348,13 +1383,15 @@ def _check_list_append(
     live_value_names: set[str] | None,
     verb: str,
 ) -> None:
-    """v2 — shared list-append validation. Five checks:
+    """v2 — shared list-append/retract validation. Five checks:
       1. Live-value restriction (§7).
       2. Target exists and is a list.
       3. Item resolves to a value (NameRef must exist; field access checked).
       4. Item type matches the list's element category (§3).
       5. Self-mutation guard inside `each` (§6).
     """
+    # `add` reads naturally with "to"; `remove` reads with "from".
+    prep = "from" if verb == "remove" else "to"
     names = live_value_names or set()
     if target_name in names:
         raise _SemanticError(
@@ -1370,14 +1407,15 @@ def _check_list_append(
     entry = symtab[target_name]
     if entry.type not in _LIST_ITEM_CATEGORY:
         raise _SemanticError(
-            f"I can only {verb} to a list. "
+            f"I can only {verb} {prep} a list. "
             f"'{target_name}' is {_singular(entry.type)}."
         )
 
     if iterator is not None and iterator.collection_name == target_name:
         raise _SemanticError(
             f"'{target_name}' is the list being iterated — you can't "
-            f"{verb} to it while iterating. Try {verb}ing to a different list."
+            f"{verb} {prep} it while iterating. "
+            f"Try {verb}ing {prep} a different list."
         )
 
     item_type, item_label = _infer_add_item_type(item_node, symtab, iterator)
@@ -1391,9 +1429,10 @@ def _check_list_append(
     ):
         return
     if item_type != expected:
+        action = "removed from" if verb == "remove" else "added to"
         raise _SemanticError(
             f"'{target_name}' is {_singular(entry.type)}. "
-            f"'{item_label}' is {_singular(item_type)} and can't be added to it."
+            f"'{item_label}' is {_singular(item_type)} and can't be {action} it."
         )
 
 

--- a/src/liminate/interpreter.py
+++ b/src/liminate/interpreter.py
@@ -79,6 +79,7 @@ from .parser import (
     NumberLiteral,
     PackVerbNode,
     QuotedString,
+    RemoveNode,
     RememberCompositionNode,
     RememberListNode,
     RememberRecordNode,
@@ -516,6 +517,8 @@ def _exec_op(
         return _exec_pack_verb(node, symtab)
     if isinstance(node, AddNode):
         return _exec_add(node, symtab, current_item)
+    if isinstance(node, RemoveNode):
+        return _exec_remove(node, symtab, current_item)
     if isinstance(node, FinishNode):
         # v3a §112 — immediate and total. The exception unwinds out of
         # any surrounding choose/sequence/composition straight to the
@@ -973,6 +976,37 @@ def _exec_add(
     return []
 
 
+def _exec_remove(
+    node: RemoveNode,
+    symtab: dict[str, SymbolEntry],
+    current_item: Any,
+) -> list[str]:
+    """Retract an item from an existing list — first-occurrence removal.
+
+    Iterator-first resolution for BareWord items (mirrors `_exec_add`):
+    inside an `each` over records, a bare name that is a field on the
+    current record resolves to that field's value. Errors if the item
+    is not in the list — `remove` is explicit, not silent.
+    """
+    entry = symtab[node.target.name]
+    item_node = node.item
+    if (
+        isinstance(item_node, BareWord)
+        and isinstance(current_item, dict)
+        and item_node.word in current_item
+    ):
+        item_value: Any = current_item[item_node.word]
+    else:
+        item_value = _evaluate_expression(item_node, symtab, current_item)
+    if item_value not in entry.value:
+        raise _RuntimeError(
+            f"I can't find '{_format_scalar(item_value)}' in "
+            f"'{node.target.name}'."
+        )
+    entry.value.remove(item_value)
+    return []
+
+
 def _exec_combine(node: CombineNode, symtab: dict[str, SymbolEntry]) -> list[str]:
     entry = symtab[node.target.name]
     total = sum(entry.value)
@@ -1319,6 +1353,14 @@ def _apply_op(op: str, a: Any, b: Any) -> bool:
         return not (a < b)   # ≥
     if op == "not_equal_to":
         return a != b
+    if op == "includes":
+        if isinstance(a, list):
+            return b in a
+        return False
+    if op == "not_includes":
+        if isinstance(a, list):
+            return b not in a
+        return True
     raise _RuntimeError(f"Unknown comparison operator '{op}'.")
 
 

--- a/src/liminate/parser.py
+++ b/src/liminate/parser.py
@@ -304,6 +304,18 @@ class AddNode(ASTNode):
 
 
 @dataclass
+class RemoveNode(ASTNode):
+    """Retract an item from an existing list.
+
+    Same slot shape as `AddNode`: `item` is the value being removed and
+    `target` is the list to remove from. Runtime error if `item` is not
+    in the list — `remove` is explicit, not silent.
+    """
+    item: ASTNode
+    target: NameRef
+
+
+@dataclass
 class FinishNode(ASTNode):
     """v3a §112 — exit listener mode immediately and totally.
 
@@ -662,6 +674,8 @@ def _parse_verb_statement(stream: TokenStream, comp: set[str]) -> ASTNode:
         return _parse_choose(stream, comp)
     if verb.value == "add":
         return _parse_add(stream)
+    if verb.value == "remove":
+        return _parse_remove(stream)
     if verb.value == "finish":
         # v3a §112 — slot-less verb. Phase 1 semantic check (in the
         # analyzer) rejects calls outside an action-block context; here
@@ -1212,6 +1226,34 @@ def _parse_add(stream: TokenStream) -> AddNode:
 
 
 # ---------------------------------------------------------------------------
+# remove — retract an item from an existing list
+# ---------------------------------------------------------------------------
+
+
+def _parse_remove(stream: TokenStream) -> RemoveNode:
+    """`remove [article]? <item-value> from [article]? <list-name>`."""
+    _consume_optional_article(stream)
+    if stream.at_end():
+        raise _ParseError(
+            "'remove' needs an item and a target list — try: "
+            "remove <item> from <list-name>."
+        )
+    item = _parse_value(stream)
+    from_tok = stream.consume()
+    if not (
+        from_tok and from_tok.type is TokenType.CONNECTIVE
+        and from_tok.value == "from"
+    ):
+        raise _ParseError(
+            "'remove' needs a source list — try: "
+            "remove <item> from <list-name>."
+        )
+    _consume_optional_article(stream)
+    target = _consume_target(stream, verb="remove")
+    return RemoveNode(item=item, target=target)
+
+
+# ---------------------------------------------------------------------------
 # gather
 # ---------------------------------------------------------------------------
 
@@ -1477,6 +1519,26 @@ def _parse_simple_condition(stream: TokenStream) -> ConditionNode:
                 f"it's used as a {cat} and can't be used as a field name."
             )
         raise _ParseError(f"I didn't expect '{head.value}' as a field name.")
+
+    # `includes` is a list-membership connective; it replaces the entire
+    # `is <op>` pattern: `<list> includes <value>` or
+    # `<list> not includes <value>`.
+    nxt = stream.peek()
+    if nxt and nxt.type is TokenType.CONNECTIVE and nxt.value == "includes":
+        stream.consume()
+        value = _parse_value(stream)
+        return ConditionNode(field=field_node, op="includes", value=value)
+    if nxt and nxt.type is TokenType.OPERATOR and nxt.value == "not":
+        after = stream.peek(1)
+        if (
+            after is not None
+            and after.type is TokenType.CONNECTIVE
+            and after.value == "includes"
+        ):
+            stream.consume()  # not
+            stream.consume()  # includes
+            value = _parse_value(stream)
+            return ConditionNode(field=field_node, op="not_includes", value=value)
 
     is_tok = stream.consume()
     if not (is_tok and is_tok.type is TokenType.OPERATOR and is_tok.value == "is"):

--- a/src/liminate/renderer.py
+++ b/src/liminate/renderer.py
@@ -44,6 +44,7 @@ from .parser import (
     NumberLiteral,
     PackVerbNode,
     QuotedString,
+    RemoveNode,
     RememberCompositionNode,
     RememberListNode,
     RememberRecordNode,
@@ -174,6 +175,9 @@ def render(node: ASTNode) -> str:
     if isinstance(node, AddNode):
         # Liminate `add` v1 §10 — canonical form: `add <item> to <list>`.
         return f"add {render(node.item)} to {node.target.name}"
+    if isinstance(node, RemoveNode):
+        # Canonical form: `remove <item> from <list>`.
+        return f"remove {render(node.item)} from {node.target.name}"
 
     if isinstance(node, PackVerbNode):
         # v4a §137 + v2: pack verbs render as `<word> [<conn>] <value>...`
@@ -332,6 +336,10 @@ def _render_condition(node: ConditionNode) -> str:
         return f"{field} is {_OP_WORDS[node.op]} {value}"
     if node.op in _NEGATED_OPS:
         return f"{field} is {_NEGATED_OPS[node.op]} {value}"
+    if node.op == "includes":
+        return f"{field} includes {value}"
+    if node.op == "not_includes":
+        return f"{field} not includes {value}"
     raise ValueError(f"unknown condition operator '{node.op}'")
 
 

--- a/src/liminate/vocabulary.py
+++ b/src/liminate/vocabulary.py
@@ -17,6 +17,8 @@ Sources:
   slot signatures via JSON; pack words add to the active vocabulary on
   activation and are removed on deactivation; the base vocabulary stays
   permanently at 34 reserved words.)
+- `includes` connective + `remove` verb addendum (12 verbs, 15 connectives,
+  37 reserved words total).
 """
 
 from dataclasses import dataclass
@@ -50,7 +52,7 @@ class Token:
 VERBS: frozenset[str] = frozenset({
     "remember", "show", "filter", "keep",
     "count", "gather", "combine", "each",
-    "choose", "finish", "add",
+    "choose", "finish", "add", "remove",
 })
 
 # v1 / v2a / v2d / v3a connectives. v2a §68 added `of`. v2d §99 added
@@ -60,7 +62,7 @@ VERBS: frozenset[str] = frozenset({
 # V2_RESERVED to active connectives.
 CONNECTIVES: frozenset[str] = frozenset({
     "where", "and", "or", "from", "with", "called", "to", "how", "as", "of",
-    "if", "otherwise", "when", "unless",
+    "if", "otherwise", "when", "unless", "includes",
 })
 
 # v1 single-word operators (inception §11). `equal to` is a multi-word
@@ -92,8 +94,10 @@ V2_RESERVED: frozenset[str] = frozenset({
 # dependent on what word follows (v1a §29, v1c §47).
 MULTI_WORD_RESERVED: frozenset[str] = frozenset({"equal"})
 
-# All 35 reserved words. v3a §124 was 34 (+1 for `finish`). Liminate
+# All 37 reserved words. v3a §124 was 34 (+1 for `finish`). Liminate
 # `add` verb addendum v1 §9: +1 for `add` (appends an item to a list).
+# `includes` connective + `remove` verb addendum: +2 (list membership
+# test in conditions, retract item from a list).
 ALL_RESERVED: frozenset[str] = (
     VERBS | CONNECTIVES | OPERATORS | ARTICLES | V2_RESERVED | MULTI_WORD_RESERVED
 )
@@ -109,7 +113,7 @@ def reserved_category(word: str) -> str | None:
     v4a §137: active pack verbs report as "verb"; active pack nouns
     report as "noun". Pack words are only reserved while the pack that
     declared them is loaded — the base vocabulary stays permanently at
-    34 words.
+    37 words.
     """
     if word in VERBS:
         return "verb"
@@ -279,4 +283,6 @@ VERB_SIGNATURES: dict[str, list[str]] = {
     "finish":   [],
     # Liminate `add` v1 §2: append an item to an existing list.
     "add":      ["item", "target"],
+    # `remove` — retract an item from an existing list.
+    "remove":   ["item", "target"],
 }

--- a/tests/test_integration_includes_remove.py
+++ b/tests/test_integration_includes_remove.py
@@ -1,0 +1,195 @@
+"""Integration tests for the `includes` connective and `remove` verb.
+
+`includes` is a list-membership connective usable in `when`/`unless`,
+`where`, and `choose if` conditions. `remove` retracts an item from a
+list (mirror of `add`).
+"""
+
+from __future__ import annotations
+
+from liminate.cli import Session
+from liminate.result import ResultStatus
+
+
+def run_lines(lines):
+    session = Session()
+    results = [session.run_line(line) for line in lines]
+    return session, results
+
+
+# ---------------------------------------------------------------------------
+# remove — happy path and behaviors
+# ---------------------------------------------------------------------------
+
+
+def test_remove_string_from_list_of_strings():
+    session, results = run_lines([
+        "remember a list called names with alice and bob and charlie",
+        "remove bob from names",
+        "show names",
+    ])
+    assert results[1].status is ResultStatus.SUCCESS, results[1].message
+    assert results[1].output is None  # silent mutation
+    assert session.symtab["names"].value == ["alice", "charlie"]
+    assert results[2].output == ["alice, charlie"]
+
+
+def test_remove_decreases_length_by_one():
+    session, _ = run_lines([
+        "remember a list called scores with 10 and 20 and 30",
+        "remove 20 from scores",
+    ])
+    assert session.symtab["scores"].value == [10, 30]
+
+
+def test_remove_missing_item_is_error():
+    _, results = run_lines([
+        "remember a list called names with alice and bob",
+        "remove charlie from names",
+    ])
+    # Runtime errors surface as ERROR_SEMANTIC (status mapping mirrors
+    # other interpreter-time failures like missing field access).
+    assert results[1].status is ResultStatus.ERROR_SEMANTIC
+    assert results[1].message == "I can't find 'charlie' in 'names'."
+
+
+def test_remove_first_occurrence_only():
+    session, _ = run_lines([
+        "remember a list called tags with urgent and review and urgent",
+        "remove urgent from tags",
+    ])
+    # First occurrence removed, second still present.
+    assert session.symtab["tags"].value == ["review", "urgent"]
+
+
+def test_remove_then_add_clean_replacement():
+    session, _ = run_lines([
+        "remember a list called decisions with none",
+        "add use-flask to decisions",
+        "add use-fastapi to decisions",
+        "remove use-flask from decisions",
+    ])
+    assert session.symtab["decisions"].value == ["use-fastapi"]
+
+
+def test_remove_from_non_list_is_error():
+    _, results = run_lines([
+        "remember a value called total with 100",
+        "remove 5 from total",
+    ])
+    assert results[1].status is ResultStatus.ERROR_SEMANTIC
+    assert results[1].message == (
+        "I can only remove from a list. 'total' is a number."
+    )
+
+
+def test_remove_self_mutation_inside_each_is_error():
+    _, results = run_lines([
+        "remember a list called items with a and b and c",
+        "each the items remove each from items",
+    ])
+    # Either analyzer rejects at parse/analyze, or runtime — either way
+    # we should not get SUCCESS. Confirm it's an error.
+    assert results[1].status is not ResultStatus.SUCCESS
+
+
+# ---------------------------------------------------------------------------
+# includes — list membership in `when` conditions (Phase 2 driving)
+# ---------------------------------------------------------------------------
+
+
+def test_includes_in_choose_if_taken_when_present():
+    _, results = run_lines([
+        "remember a list called tags with urgent and review",
+        'choose if tags includes "urgent": show "yes" otherwise show "no"',
+    ])
+    assert results[1].status is ResultStatus.SUCCESS, results[1].message
+    assert results[1].output == ["yes"]
+
+
+def test_includes_in_choose_if_not_taken_when_absent():
+    _, results = run_lines([
+        "remember a list called tags with review",
+        'choose if tags includes "urgent": show "yes" otherwise show "no"',
+    ])
+    assert results[1].output == ["no"]
+
+
+def test_not_includes_in_choose_if():
+    _, results = run_lines([
+        "remember a list called tags with review",
+        'choose if tags not includes "urgent": show "ok" otherwise show "skip"',
+    ])
+    assert results[1].output == ["ok"]
+
+
+def test_includes_with_scalar_left_operand_is_false():
+    # A non-list on the left of `includes` evaluates to false (not an
+    # error) — `includes` is a list-membership probe.
+    _, results = run_lines([
+        "remember a value called name with alice",
+        'choose if name includes "alice": show "yes" otherwise show "no"',
+    ])
+    assert results[1].status is ResultStatus.SUCCESS
+    assert results[1].output == ["no"]
+
+
+def test_includes_none_seed_then_add_clears_seed():
+    # Before any `add`, the `none`-seeded list literally contains "none".
+    _, results = run_lines([
+        "remember a list called decisions with none",
+        'choose if decisions includes "none": show "seed" otherwise show "real"',
+    ])
+    assert results[1].output == ["seed"]
+
+    _, results2 = run_lines([
+        "remember a list called decisions with none",
+        "add use-fastapi to decisions",
+        'choose if decisions includes "none": show "seed" otherwise show "real"',
+    ])
+    assert results2[2].output == ["real"]
+
+
+# ---------------------------------------------------------------------------
+# Round-trip rendering
+# ---------------------------------------------------------------------------
+
+
+def test_remove_renders_canonically():
+    from liminate.lexer import tokenize
+    from liminate.parser import parse
+    from liminate.renderer import render
+
+    # `use-flask` is a single bare word — conditional quoting (v2c §90)
+    # drops the quotes on re-render because the value is single-token,
+    # all-lowercase, and not a reserved word.
+    tokens = tokenize('remove "use-flask" from the decisions')
+    ast = parse(tokens)
+    assert render(ast) == "remove use-flask from decisions"
+    # And the rendered form round-trips through the parser.
+    parse(tokenize(render(ast)))
+
+
+def test_includes_renders_canonically():
+    from liminate.lexer import tokenize
+    from liminate.parser import parse
+    from liminate.renderer import render
+
+    tokens = tokenize('choose if tags includes "urgent": show "yes"')
+    ast = parse(tokens)
+    rendered = render(ast)
+    assert "tags includes" in rendered
+    # Round-trip: rendered form must re-parse.
+    parse(tokenize(rendered))
+
+
+def test_not_includes_renders_canonically():
+    from liminate.lexer import tokenize
+    from liminate.parser import parse
+    from liminate.renderer import render
+
+    tokens = tokenize('choose if tags not includes "urgent": show "yes"')
+    ast = parse(tokens)
+    rendered = render(ast)
+    assert "tags not includes" in rendered
+    parse(tokenize(rendered))

--- a/tests/test_vocabulary.py
+++ b/tests/test_vocabulary.py
@@ -17,24 +17,24 @@ from liminate.vocabulary import (
 
 
 def test_verb_count():
-    # Liminate `add` v1 §9: 11 verbs (was 10 in v3a §124; `add` appends
-    # an item to an existing list).
-    assert len(VERBS) == 11
+    # 12 verbs: 11 (Liminate `add` v1 §9) + 1 (`remove` — retract an
+    # item from a list).
+    assert len(VERBS) == 12
     assert VERBS == {
         "remember", "show", "filter", "keep", "count",
-        "gather", "combine", "each", "choose", "finish", "add",
+        "gather", "combine", "each", "choose", "finish", "add", "remove",
     }
 
 
 def test_connective_count():
-    # v3a §124: 14 connectives (was 12 in v2d §104; `when` and `unless`
-    # promoted from V2_RESERVED in v3a §108/§109 for the listener model).
-    assert len(CONNECTIVES) == 14
+    # 15 connectives: v3a §124 had 14; `includes` adds the list-membership
+    # connective used in `when`/`where`/`choose if` conditions.
+    assert len(CONNECTIVES) == 15
     assert CONNECTIVES == {
         "where", "and", "or", "from", "with",
         "called", "to", "how", "as", "of",
         "if", "otherwise",
-        "when", "unless",
+        "when", "unless", "includes",
     }
 
 
@@ -66,11 +66,11 @@ def test_multi_word_reserved():
     assert MULTI_WORD_RESERVED == {"equal"}
 
 
-def test_total_reserved_count_is_35():
-    # Liminate `add` v1 §9: 35 reserved words total (was 34 in v3a §124).
-    # Delta: +1 `add` verb. 11 verbs + 14 connectives + 4 operators
-    # + 1 multi-word + 3 articles + 2 v2-deferred verbs = 35.
-    assert len(ALL_RESERVED) == 35
+def test_total_reserved_count_is_37():
+    # 37 reserved words total. Delta from 35 (Liminate `add` v1 §9):
+    # +1 `remove` verb, +1 `includes` connective. 12 verbs + 15 connectives
+    # + 4 operators + 1 multi-word + 3 articles + 2 v2-deferred verbs = 37.
+    assert len(ALL_RESERVED) == 37
 
 
 def test_reserved_sets_are_disjoint():
@@ -124,6 +124,8 @@ def test_verb_signature_slot_shapes():
     assert VERB_SIGNATURES["finish"] == []
     # Liminate `add` v1 §2: append an item to an existing list.
     assert VERB_SIGNATURES["add"] == ["item", "target"]
+    # `remove` — retract an item from an existing list (same slot shape).
+    assert VERB_SIGNATURES["remove"] == ["item", "target"]
 
 
 def test_add_is_classified_as_verb():


### PR DESCRIPTION
## Summary

Extends the base vocabulary from 35 → 37 reserved words: **12 verbs, 15 connectives**.

- **`includes`** (connective) — list-membership test in `when`/`where`/`choose if` conditions. Replaces the `is <op>` pattern with a direct `<list> includes <value>` form. Supports `not includes` negation. Non-list left operand evaluates to false (not an error).
- **`remove`** (verb) — retracts an item from an existing list. Mirrors `add`'s slot shape but uses `from` instead of `to` (`remove <item> from <list>`). First-occurrence semantics; runtime error if the item is not present.

Motivates inheritance-guard and decision-reversal patterns, e.g.:

```
when inherited-decisions includes "use-fastapi"
  show "Constraint: FastAPI is locked"

remove "use-flask" from tracked-decisions
```

## Test plan

- [x] `pytest tests/` — 850 passed (835 prior + 15 new)
- [x] `len(VERBS) == 12`, `len(CONNECTIVES) == 15`, `len(ALL_RESERVED) == 37`
- [x] Decision reversal program (`add`/`add`/`remove`/`show`) — verified end-to-end
- [x] Inheritance guard pattern (`choose if list includes …`) — verified
- [x] Combined includes + remove integration — verified
- [x] Canonical round-trip rendering for `includes`, `not includes`, and `remove`

🤖 Generated with [Claude Code](https://claude.com/claude-code)