### PR TITLE
fix: add `includes`/`not_includes` to listener's `_apply_op`

### DIFF
--- a/src/liminate/interpreter.py
+++ b/src/liminate/interpreter.py
@@ -1339,6 +1339,9 @@ def _eval_value(value_node: ASTNode, current_item: Any, symtab) -> Any:
 
 
 def _apply_op(op: str, a: Any, b: Any) -> bool:
+    # NOTE: this function is duplicated in listener.py to avoid a circular
+    # import between interpreter and listener. Both copies must stay in
+    # sync when adding new operators.
     if op == "is":
         return a == b
     if op == "above":

--- a/src/liminate/listener.py
+++ b/src/liminate/listener.py
@@ -670,7 +670,11 @@ def _snapshot_value(entry: SymbolEntry | None) -> Any:
 def _apply_op(op: str, a: Any, b: Any) -> bool:
     """Operator dispatch shared with the sequential interpreter. Keeping
     a copy here avoids the circular import between interpreter and
-    listener modules."""
+    listener modules.
+
+    NOTE: this function is duplicated in interpreter.py. Both copies
+    must stay in sync when adding new operators.
+    """
     if op == "is":
         return a == b
     if op == "above":
@@ -685,4 +689,12 @@ def _apply_op(op: str, a: Any, b: Any) -> bool:
         return not (a < b)
     if op == "not_equal_to":
         return a != b
+    if op == "includes":
+        if isinstance(a, list):
+            return b in a
+        return False
+    if op == "not_includes":
+        if isinstance(a, list):
+            return b not in a
+        return True
     raise ValueError(f"Unknown comparison operator '{op}'.")

--- a/tests/test_integration_includes_remove.py
+++ b/tests/test_integration_includes_remove.py
@@ -193,3 +193,78 @@ def test_not_includes_renders_canonically():
     rendered = render(ast)
     assert "tags not includes" in rendered
     parse(tokenize(rendered))
+
+
+# ---------------------------------------------------------------------------
+# Listener path — `when ... includes` fires during initial evaluation.
+#
+# Regression guard for the `_apply_op` duplication between interpreter.py
+# and listener.py: when new operators are added to one copy they must
+# also be added to the other, otherwise a `when` handler that parses and
+# registers fine will raise "Unknown comparison operator" at firing time.
+# ---------------------------------------------------------------------------
+
+
+def _drain(iterable):
+    return list(iterable)
+
+
+def test_when_includes_fires_on_initial_evaluation():
+    from liminate.adapter import LiveValueRegistry
+    from liminate.analyzer import SymbolEntry
+    from liminate.interpreter import HandlerTable, execute as _execute
+    from liminate.lexer import tokenize
+    from liminate.listener import listen
+    from liminate.parser import parse_when_block
+    from liminate.reorderer import reorder
+
+    symtab: dict[str, SymbolEntry] = {}
+    symtab["decisions"] = SymbolEntry(
+        name="decisions",
+        value=["use-fastapi"],
+        type="list_of_strings",
+    )
+    ht = HandlerTable()
+    reg = LiveValueRegistry()
+
+    htoks = reorder(tokenize('when decisions includes "use-fastapi"'))
+    atoks = [reorder(tokenize('show "Constraint active"'))]
+    ast = parse_when_block(htoks, atoks)
+    reg_result = _execute(ast, symtab, handler_table=ht, live_value_registry=reg)
+    assert reg_result.status is ResultStatus.SUCCESS, reg_result.message
+
+    results = _drain(listen(symtab, ht, reg, adapters=[]))
+    fires = [r for r in results if r.status is ResultStatus.HANDLER_FIRE]
+    assert len(fires) == 1
+    assert fires[0].output == ["Constraint active"]
+    assert fires[0].metadata["trigger"]["source"] == "initial"
+
+
+def test_when_not_includes_fires_on_initial_evaluation():
+    from liminate.adapter import LiveValueRegistry
+    from liminate.analyzer import SymbolEntry
+    from liminate.interpreter import HandlerTable, execute as _execute
+    from liminate.lexer import tokenize
+    from liminate.listener import listen
+    from liminate.parser import parse_when_block
+    from liminate.reorderer import reorder
+
+    symtab: dict[str, SymbolEntry] = {}
+    symtab["decisions"] = SymbolEntry(
+        name="decisions",
+        value=["use-fastapi"],
+        type="list_of_strings",
+    )
+    ht = HandlerTable()
+    reg = LiveValueRegistry()
+
+    htoks = reorder(tokenize('when decisions not includes "use-flask"'))
+    atoks = [reorder(tokenize('show "flask not active"'))]
+    ast = parse_when_block(htoks, atoks)
+    reg_result = _execute(ast, symtab, handler_table=ht, live_value_registry=reg)
+    assert reg_result.status is ResultStatus.SUCCESS, reg_result.message
+
+    results = _drain(listen(symtab, ht, reg, adapters=[]))
+    fires = [r for r in results if r.status is ResultStatus.HANDLER_FIRE]
+    assert len(fires) == 1
+    assert fires[0].output == ["flask not active"]


### PR DESCRIPTION
## Summary

- The Phase 2 listener has its own copy of `_apply_op` (to avoid a circular import with the interpreter). The `includes` feature added the new ops to the interpreter's copy but missed the listener's, so a `when <list> includes <item>` handler would register fine and then raise `Unknown comparison operator 'includes'` at firing time.
- Adds `includes` and `not_includes` to the listener's `_apply_op` with identical semantics to the interpreter's copy (non-list left operand → `False` for `includes`, `True` for `not_includes`).
- Adds a NOTE comment to both copies flagging the duplication so future operator additions don't drift again.

## Test plan

- [x] `pytest tests/` — 852 passed (850 prior + 2 new)
- [x] New listener-path regression tests register `when … includes` and `when … not includes` handlers and assert they fire during initial evaluation with the expected output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)