### PR TITLE
feat: add `measure` verb + `within` connective + numeric_extract_compare

### DIFF
--- a/examples/pack_session.json
+++ b/examples/pack_session.json
@@ -34,6 +34,24 @@
         "status_target": "verification-status",
         "details_target": "verification-divergences"
       }
+    },
+    {
+      "word": "measure",
+      "slots": [
+        { "name": "value", "connective": null, "required": true, "value_type": "value" },
+        { "name": "source", "connective": "from", "required": true, "value_type": "name", "type_constraint": "source" },
+        { "name": "tolerance", "connective": "within", "required": true, "value_type": "value" }
+      ],
+      "execution": {
+        "type": "numeric_extract_compare",
+        "check_slot": "value",
+        "against_slot": "source",
+        "tolerance_slot": "tolerance",
+        "on_mismatch": "flag",
+        "status_target": "measure-status",
+        "matched_target": "measure-matched",
+        "delta_target": "measure-delta"
+      }
     }
   ],
   "declarations": [],

--- a/src/liminate/adapter.py
+++ b/src/liminate/adapter.py
@@ -30,6 +30,7 @@ from typing import Any
 from .vocabulary import (
     AppendToListExecution,
     CompareValuesExecution,
+    NumericExtractCompareExecution,
     PackVerbExecution,
     PackVerbSignature,
     PackVerbSlot,
@@ -239,10 +240,20 @@ def _parse_execution(exec_def: dict) -> PackVerbExecution:
             status_target=exec_def["status_target"],
             details_target=exec_def.get("details_target"),
         )
+    if exec_type == "numeric_extract_compare":
+        return NumericExtractCompareExecution(
+            check_slot=exec_def["check_slot"],
+            against_slot=exec_def["against_slot"],
+            tolerance_slot=exec_def["tolerance_slot"],
+            on_mismatch=exec_def.get("on_mismatch", "flag"),
+            status_target=exec_def["status_target"],
+            matched_target=exec_def["matched_target"],
+            delta_target=exec_def["delta_target"],
+        )
     raise ValueError(
         f"Unknown execution type '{exec_type}'. "
         f"Supported: set_value, substring_check, append_to_list, "
-        f"set_field, compare_values."
+        f"set_field, compare_values, numeric_extract_compare."
     )
 
 
@@ -339,6 +350,21 @@ def _validate_pack_verb_signature(sig: PackVerbSignature) -> None:
                 f"Pack verb '{word}': structural comparison requires a "
                 f"'details_target' field."
             )
+
+    # numeric_extract_compare: extra validation.
+    if isinstance(execution, NumericExtractCompareExecution):
+        if execution.on_mismatch not in ("error", "flag"):
+            raise ValueError(
+                f"Pack verb '{word}' uses unknown on_mismatch "
+                f"'{execution.on_mismatch}'. Use 'error' or 'flag'."
+            )
+        for field_name in ("status_target", "matched_target", "delta_target"):
+            v = getattr(execution, field_name)
+            if not isinstance(v, str) or not v:
+                raise ValueError(
+                    f"Pack verb '{word}': '{field_name}' must be a "
+                    f"non-empty string."
+                )
 
 
 def parse_pack_verb_signature(definition: dict) -> PackVerbSignature:

--- a/src/liminate/analyzer.py
+++ b/src/liminate/analyzer.py
@@ -81,6 +81,7 @@ from .result import LiminateResult, ResultStatus
 from .vocabulary import (
     AppendToListExecution,
     CompareValuesExecution,
+    NumericExtractCompareExecution,
     SetFieldExecution,
     SetValueExecution,
     SubstringCheckExecution,
@@ -1171,6 +1172,8 @@ def _check_pack_verb(
         _check_pack_set_field(node, execution, symtab)
     elif isinstance(execution, CompareValuesExecution):
         _check_pack_compare(node, execution, symtab)
+    elif isinstance(execution, NumericExtractCompareExecution):
+        _check_pack_numeric_extract(node, execution, symtab)
     # SetValueExecution: nothing further beyond type_constraint loop.
 
 
@@ -1307,6 +1310,31 @@ def _check_pack_compare(
                 f"I can't find '{value_node.name}'. "
                 f"You might need to 'remember' it first."
             )
+
+
+def _check_pack_numeric_extract(
+    node: PackVerbNode,
+    execution: NumericExtractCompareExecution,
+    symtab: dict[str, SymbolEntry],
+) -> None:
+    """Analyzer validation for numeric_extract_compare."""
+    against_node = node.slot_values.get(execution.against_slot)
+    if not isinstance(against_node, NameRef):
+        raise _SemanticError(
+            f"'{node.word}' expects a name for the source text."
+        )
+    name = against_node.name
+    if name not in symtab:
+        raise _SemanticError(
+            f"I can't find '{name}'. "
+            f"You might need to 'remember' it first."
+        )
+    entry = symtab[name]
+    if entry.type != "string":
+        raise _SemanticError(
+            f"'{node.word} from' expects text, but '{name}' is "
+            f"{_singular(entry.type)}."
+        )
 
 
 def _check_finish(

--- a/src/liminate/interpreter.py
+++ b/src/liminate/interpreter.py
@@ -31,6 +31,7 @@ semantics (v1d §56).
 from __future__ import annotations
 
 import copy
+import re
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from typing import Any
@@ -40,6 +41,7 @@ from .analyzer import SymbolEntry, analyze
 from .vocabulary import (
     AppendToListExecution,
     CompareValuesExecution,
+    NumericExtractCompareExecution,
     SetFieldExecution,
     SetValueExecution,
     SubstringCheckExecution,
@@ -631,6 +633,8 @@ def _exec_pack_verb(
         return _exec_pack_set_field(node, execution, symtab)
     if isinstance(execution, CompareValuesExecution):
         return _exec_pack_compare_values(node, execution, symtab)
+    if isinstance(execution, NumericExtractCompareExecution):
+        return _exec_pack_numeric_extract_compare(node, execution, symtab)
     raise _RuntimeError(
         f"Pack verb '{node.word}' has an unrecognized execution type."
     )
@@ -838,6 +842,72 @@ def _exec_pack_compare_values(
             )
         raise _RuntimeError(
             f"'{left_name}' does not match '{right_name}'."
+        )
+    return []
+
+
+def _exec_pack_numeric_extract_compare(
+    node: PackVerbNode,
+    execution: NumericExtractCompareExecution,
+    symtab: dict[str, SymbolEntry],
+) -> list[str]:
+    """Sixth execution type: extract all numbers from a source string,
+    find the closest to the claimed value, check tolerance."""
+    check_node = node.slot_values.get(execution.check_slot)
+    against_node = node.slot_values.get(execution.against_slot)
+    tolerance_node = node.slot_values.get(execution.tolerance_slot)
+
+    claimed = _evaluate_expression(check_node, symtab, None)
+    source_text = _evaluate_expression(against_node, symtab, None)
+    tolerance = _evaluate_expression(tolerance_node, symtab, None)
+
+    if not isinstance(claimed, (int, float)):
+        claimed = float(_format_scalar(claimed))
+    if not isinstance(tolerance, (int, float)):
+        tolerance = float(_format_scalar(tolerance))
+    if not isinstance(source_text, str):
+        source_text = _format_scalar(source_text)
+
+    numbers = [float(m) for m in re.findall(r'-?\d+\.?\d*', source_text)]
+
+    if not numbers:
+        against_name = (
+            against_node.name if isinstance(against_node, NameRef)
+            else execution.against_slot
+        )
+        if execution.on_mismatch == "error":
+            raise _RuntimeError(
+                f"No numbers found in '{against_name}'."
+            )
+        _store(symtab, execution.status_target, "no_numbers_found")
+        _store(symtab, execution.matched_target, "none")
+        _store(symtab, execution.delta_target, "none")
+        return []
+
+    closest = min(numbers, key=lambda n: abs(n - claimed))
+    delta = abs(claimed - closest)
+
+    if closest == int(closest):
+        closest = int(closest)
+    if delta == int(delta):
+        delta = int(delta)
+
+    within = delta <= tolerance
+    status = "within_tolerance" if within else "outside_tolerance"
+    _store(symtab, execution.status_target, status)
+    _store(symtab, execution.matched_target, closest)
+    _store(symtab, execution.delta_target, delta)
+
+    if not within and execution.on_mismatch == "error":
+        against_name = (
+            against_node.name if isinstance(against_node, NameRef)
+            else execution.against_slot
+        )
+        raise _RuntimeError(
+            f"Claimed {_format_scalar(claimed)} but closest value in "
+            f"'{against_name}' is {_format_scalar(closest)} "
+            f"(delta: {_format_scalar(delta)}, tolerance: "
+            f"{_format_scalar(tolerance)})."
         )
     return []
 

--- a/src/liminate/vocabulary.py
+++ b/src/liminate/vocabulary.py
@@ -19,6 +19,9 @@ Sources:
   permanently at 34 reserved words.)
 - `includes` connective + `remove` verb addendum (12 verbs, 15 connectives,
   37 reserved words total).
+- `within` connective addendum (12 verbs, 16 connectives, 38 reserved
+  words total) — used by the session pack's `measure` verb for numeric
+  tolerance.
 """
 
 from dataclasses import dataclass
@@ -62,7 +65,7 @@ VERBS: frozenset[str] = frozenset({
 # V2_RESERVED to active connectives.
 CONNECTIVES: frozenset[str] = frozenset({
     "where", "and", "or", "from", "with", "called", "to", "how", "as", "of",
-    "if", "otherwise", "when", "unless", "includes",
+    "if", "otherwise", "when", "unless", "includes", "within",
 })
 
 # v1 single-word operators (inception §11). `equal to` is a multi-word
@@ -94,10 +97,11 @@ V2_RESERVED: frozenset[str] = frozenset({
 # dependent on what word follows (v1a §29, v1c §47).
 MULTI_WORD_RESERVED: frozenset[str] = frozenset({"equal"})
 
-# All 37 reserved words. v3a §124 was 34 (+1 for `finish`). Liminate
+# All 38 reserved words. v3a §124 was 34 (+1 for `finish`). Liminate
 # `add` verb addendum v1 §9: +1 for `add` (appends an item to a list).
 # `includes` connective + `remove` verb addendum: +2 (list membership
-# test in conditions, retract item from a list).
+# test in conditions, retract item from a list). `within` connective: +1
+# (numeric tolerance for the session pack's `measure` verb).
 ALL_RESERVED: frozenset[str] = (
     VERBS | CONNECTIVES | OPERATORS | ARTICLES | V2_RESERVED | MULTI_WORD_RESERVED
 )
@@ -113,7 +117,7 @@ def reserved_category(word: str) -> str | None:
     v4a §137: active pack verbs report as "verb"; active pack nouns
     report as "noun". Pack words are only reserved while the pack that
     declared them is loaded — the base vocabulary stays permanently at
-    37 words.
+    38 words.
     """
     if word in VERBS:
         return "verb"
@@ -198,12 +202,24 @@ class CompareValuesExecution:
     details_target: str | None  # required for "structural"
 
 
+@dataclass(frozen=True)
+class NumericExtractCompareExecution:
+    check_slot: str          # slot name containing the claimed number
+    against_slot: str        # slot name containing the source text (string)
+    tolerance_slot: str      # slot name containing the tolerance number
+    on_mismatch: str         # "error" | "flag"
+    status_target: str       # symbol name for "within_tolerance" / "outside_tolerance"
+    matched_target: str      # symbol name for the closest number found in source
+    delta_target: str        # symbol name for the absolute difference
+
+
 PackVerbExecution = (
     SetValueExecution
     | SubstringCheckExecution
     | AppendToListExecution
     | SetFieldExecution
     | CompareValuesExecution
+    | NumericExtractCompareExecution
 )
 
 

--- a/tests/test_integration_session_pack.py
+++ b/tests/test_integration_session_pack.py
@@ -295,3 +295,163 @@ def test_pack_verbs_reserved_when_pack_active():
         errors = [r for r in results if r.status is ResultStatus.ERROR_PARSE]
         assert errors, f"expected error for reserved verb '{verb}'"
         assert "verb" in errors[0].message
+
+
+# ---------------------------------------------------------------------------
+# measure — happy path: within tolerance
+# ---------------------------------------------------------------------------
+
+
+def test_measure_within_tolerance():
+    """measure passes when closest number is within tolerance."""
+    session, results = run_v3a(
+        """
+        remember a source called report with "The cohort held 76 percent of weeks employed."
+        measure 76.3 from report within 1
+        """,
+        pack=_load_session_pack(),
+    )
+    errors = [r for r in results if r.status is ResultStatus.ERROR_SEMANTIC]
+    assert not errors, errors
+    assert session.symtab["measure-status"].value == "within_tolerance"
+    assert session.symtab["measure-matched"].value == 76
+    assert session.symtab["measure-delta"].value < 1
+
+
+def test_measure_exact_match():
+    """measure passes with delta 0 when the number matches exactly."""
+    session, results = run_v3a(
+        """
+        remember a source called report with "They held an average of 9.0 jobs."
+        measure 9.0 from report within 0.1
+        """,
+        pack=_load_session_pack(),
+    )
+    errors = [r for r in results if r.status is ResultStatus.ERROR_SEMANTIC]
+    assert not errors, errors
+    assert session.symtab["measure-status"].value == "within_tolerance"
+
+
+def test_measure_closest_of_multiple_numbers():
+    """measure finds the closest number when source has many."""
+    session, results = run_v3a(
+        """
+        remember a source called report with "78 percent of White workers. 75 percent Hispanic. 68 percent Black."
+        measure 78.3 from report within 1
+        """,
+        pack=_load_session_pack(),
+    )
+    errors = [r for r in results if r.status is ResultStatus.ERROR_SEMANTIC]
+    assert not errors, errors
+    assert session.symtab["measure-matched"].value == 78
+    assert session.symtab["measure-status"].value == "within_tolerance"
+
+
+# ---------------------------------------------------------------------------
+# measure — outside tolerance (flag mode)
+# ---------------------------------------------------------------------------
+
+
+def test_measure_outside_tolerance_flags():
+    """measure flags outside_tolerance without halting."""
+    session, results = run_v3a(
+        """
+        remember a source called report with "23 percent of dropouts were limited."
+        measure 26.0 from report within 1
+        show measure-status
+        """,
+        pack=_load_session_pack(),
+    )
+    assert outputs(results) == ["outside_tolerance"]
+    assert session.symtab["measure-matched"].value == 23
+    assert session.symtab["measure-delta"].value == 3
+
+
+def test_measure_outside_tolerance_continues_execution():
+    """Execution continues after a flagged outside_tolerance."""
+    _, results = run_v3a(
+        """
+        remember a source called report with "The value is 50."
+        measure 99 from report within 1
+        show measure-status
+        show measure-matched
+        show measure-delta
+        """,
+        pack=_load_session_pack(),
+    )
+    out = outputs(results)
+    assert out[0] == "outside_tolerance"
+    assert out[1] == "50"
+    assert out[2] == "49"
+
+
+# ---------------------------------------------------------------------------
+# measure — no numbers in source
+# ---------------------------------------------------------------------------
+
+
+def test_measure_no_numbers_in_source():
+    """measure handles sources with no numeric content."""
+    session, results = run_v3a(
+        """
+        remember a source called report with "No numbers here at all."
+        measure 76 from report within 1
+        """,
+        pack=_load_session_pack(),
+    )
+    errors = [r for r in results if r.status is ResultStatus.ERROR_SEMANTIC]
+    assert not errors, errors
+    assert session.symtab["measure-status"].value == "no_numbers_found"
+
+
+# ---------------------------------------------------------------------------
+# measure — type constraint errors
+# ---------------------------------------------------------------------------
+
+
+def test_measure_from_non_source_typed_symbol_is_error():
+    """measure requires the from-arg to have descriptor 'source'."""
+    _, results = run_v3a(
+        """
+        remember a value called plain-text with "Some text with 42."
+        measure 42 from plain-text within 1
+        """,
+        pack=_load_session_pack(),
+    )
+    errors = [r for r in results if r.status is ResultStatus.ERROR_SEMANTIC]
+    assert errors, results
+    assert "plain-text" in errors[0].message
+
+
+# ---------------------------------------------------------------------------
+# measure — combined with cite
+# ---------------------------------------------------------------------------
+
+
+def test_cite_fails_but_measure_passes():
+    """The NLSY97 proof point: cite rejects imprecise text, measure
+    confirms numeric proximity."""
+    _, results = run_v3a(
+        """
+        remember a source called bls with "76 percent of weeks employed"
+        cite "76.3 percent" from bls
+        measure 76.3 from bls within 1
+        """,
+        pack=_load_session_pack(),
+    )
+    cite_errors = [r for r in results if r.status is ResultStatus.ERROR_SEMANTIC]
+    assert len(cite_errors) == 1
+    assert "76.3 percent" in cite_errors[0].message
+
+
+def test_measure_after_cite_in_separate_blocks():
+    """When cite and measure are independent checks, both produce results."""
+    _, results = run_v3a(
+        """
+        remember a source called bls with "76 percent of weeks employed"
+        measure 76.3 from bls within 1
+        show measure-status
+        """,
+        pack=_load_session_pack(),
+    )
+    assert outputs(results) == ["within_tolerance"]

--- a/tests/test_vocabulary.py
+++ b/tests/test_vocabulary.py
@@ -27,14 +27,15 @@ def test_verb_count():
 
 
 def test_connective_count():
-    # 15 connectives: v3a §124 had 14; `includes` adds the list-membership
-    # connective used in `when`/`where`/`choose if` conditions.
-    assert len(CONNECTIVES) == 15
+    # 16 connectives: v3a §124 had 14; `includes` adds list-membership for
+    # conditions; `within` introduces the tolerance value in the session
+    # pack's `measure` verb.
+    assert len(CONNECTIVES) == 16
     assert CONNECTIVES == {
         "where", "and", "or", "from", "with",
         "called", "to", "how", "as", "of",
         "if", "otherwise",
-        "when", "unless", "includes",
+        "when", "unless", "includes", "within",
     }
 
 
@@ -66,11 +67,11 @@ def test_multi_word_reserved():
     assert MULTI_WORD_RESERVED == {"equal"}
 
 
-def test_total_reserved_count_is_37():
-    # 37 reserved words total. Delta from 35 (Liminate `add` v1 §9):
-    # +1 `remove` verb, +1 `includes` connective. 12 verbs + 15 connectives
-    # + 4 operators + 1 multi-word + 3 articles + 2 v2-deferred verbs = 37.
-    assert len(ALL_RESERVED) == 37
+def test_total_reserved_count_is_38():
+    # 38 reserved words total. Delta from 37: +1 `within` connective for
+    # the session pack's `measure` verb. 12 verbs + 16 connectives
+    # + 4 operators + 1 multi-word + 3 articles + 2 v2-deferred verbs = 38.
+    assert len(ALL_RESERVED) == 38
 
 
 def test_reserved_sets_are_disjoint():


### PR DESCRIPTION
## Summary
- Adds a sixth pack-verb execution type, `numeric_extract_compare`, surfaced through a new `measure` verb in the session domain pack and a new base connective `within`.
- `measure <value> from <source> within <tolerance>` extracts all numbers from the source string, finds the closest to the claimed value, and stores status (`within_tolerance` / `outside_tolerance` / `no_numbers_found`) plus the matched number and delta.
- Fills the gap between `cite` (exact substring) and `verify` (structural compare) — distinguishes a rounding-precision mismatch ("76.3" vs "76 percent") from a fabricated number.

## Vocabulary delta
- Connectives 15 → 16 (`within`).
- Total reserved words 37 → 38.
- Pack execution types 5 → 6.
- Session pack verbs 2 → 3 (`cite`, `verify`, `measure`).

## Test plan
- [x] 852 baseline tests still pass
- [x] 9 new integration tests cover happy path, multi-number sources, flag-on-mismatch, no-numbers-found, type constraint errors, and combined cite+measure
- [x] `test_vocabulary` counts updated (37 → 38, 15 → 16)
- [x] Final: 861/861 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)