### PR TITLE
feat: add `weakens`/`over` — Metabolic Era vocabulary (38 → 40 reserved words)

### DIFF
--- a/examples/dogfood_weakens_decay.limn
+++ b/examples/dogfood_weakens_decay.limn
@@ -1,0 +1,9 @@
+remember a value called urgency with 1.0
+remember a status called task-status with "active"
+
+weakens urgency over 10
+
+show urgency
+
+when urgency is below 0.3
+  show "Review urgency has faded — reassignment needed."

--- a/src/liminate/analyzer.py
+++ b/src/liminate/analyzer.py
@@ -75,6 +75,7 @@ from .parser import (
     RememberValueNode,
     SequenceNode,
     ShowNode,
+    WeakensNode,
     WhenNode,
 )
 from .result import LiminateResult, ResultStatus
@@ -307,6 +308,8 @@ def _check(
             node, symtab, iterator,
             live_value_names=live_value_names,
         )
+    elif isinstance(node, WeakensNode):
+        _check_weakens(node, symtab, live_value_names=live_value_names)
     elif isinstance(node, FinishNode):
         # v3a §112: `finish` is legal only inside a `when` action block
         # (directly, in a `choose` branch, or in a composition called
@@ -461,6 +464,9 @@ def _side_effect_verb(
     if isinstance(node, RemoveNode):
         # `remove` — silent mutation; returns no value.
         return "remove"
+    if isinstance(node, WeakensNode):
+        # `weakens` — attaches decay metadata; returns no value.
+        return "weakens"
     if isinstance(node, (RememberListNode, RememberRecordNode, RememberCompositionNode)):
         return "remember"
     if isinstance(node, RememberValueNode):
@@ -698,6 +704,44 @@ def _check_show(
 # ---------------------------------------------------------------------------
 # filter
 # ---------------------------------------------------------------------------
+
+
+def _check_weakens(
+    node: WeakensNode,
+    symtab: dict[str, SymbolEntry],
+    *,
+    live_value_names: set[str] | None = None,
+) -> None:
+    """Metabolic Era batch 1 — validate the `weakens` verb.
+
+    1. Subject must not be a live value (adapter-owned).
+    2. Subject must exist in the symbol table.
+    3. Subject must be numeric (or `unknown` — defer to runtime).
+    4. Period must be a positive number.
+    """
+    name = node.subject.name
+    names = live_value_names or set()
+    if name in names:
+        raise _SemanticError(
+            f"'{name}' is a live value provided by the domain pack — "
+            f"you can't apply decay to it directly."
+        )
+    if name not in symtab:
+        raise _SemanticError(
+            f"I can't find '{name}'. "
+            f"You might need to 'remember' it first."
+        )
+    entry = symtab[name]
+    if entry.type not in ("number", "unknown"):
+        raise _SemanticError(
+            f"'weakens' only works on numbers — "
+            f"'{name}' is {_singular(entry.type)}."
+        )
+    if node.period.value <= 0:
+        raise _SemanticError(
+            f"The decay period must be a positive number, "
+            f"not {_fmt_number(node.period.value)}."
+        )
 
 
 def _check_filter(

--- a/src/liminate/interpreter.py
+++ b/src/liminate/interpreter.py
@@ -41,6 +41,7 @@ from .analyzer import SymbolEntry, analyze
 from .vocabulary import (
     AppendToListExecution,
     CompareValuesExecution,
+    DecayingValue,
     NumericExtractCompareExecution,
     SetFieldExecution,
     SetValueExecution,
@@ -88,6 +89,7 @@ from .parser import (
     RememberValueNode,
     SequenceNode,
     ShowNode,
+    WeakensNode,
     WhenNode,
 )
 from .renderer import render
@@ -521,6 +523,8 @@ def _exec_op(
         return _exec_add(node, symtab, current_item)
     if isinstance(node, RemoveNode):
         return _exec_remove(node, symtab, current_item)
+    if isinstance(node, WeakensNode):
+        return _exec_weakens(node, symtab)
     if isinstance(node, FinishNode):
         # v3a §112 — immediate and total. The exception unwinds out of
         # any surrounding choose/sequence/composition straight to the
@@ -1077,6 +1081,54 @@ def _exec_remove(
     return []
 
 
+def _exec_weakens(
+    node: WeakensNode,
+    symtab: dict[str, SymbolEntry],
+) -> list[str]:
+    """Metabolic Era batch 1 — attach decay metadata to a numeric variable.
+
+    If the variable is already a DecayingValue, reapplication is
+    last-wins: new period, ticks reset, initial value taken from the
+    current decayed value at the moment of reapplication.
+    """
+    entry = symtab[node.subject.name]
+    current = entry.value
+    period = node.period.value
+
+    if isinstance(current, DecayingValue):
+        current = current.current_value
+
+    if not isinstance(current, (int, float)):
+        raise _RuntimeError(
+            f"'weakens' only works on numbers — "
+            f"'{node.subject.name}' is a {type(current).__name__}."
+        )
+
+    entry.value = DecayingValue(
+        initial_value=float(current),
+        period=period,
+    )
+    # Type stays "number" — a DecayingValue IS a number with metadata.
+    return []
+
+
+def decay_tick(symtab: dict[str, SymbolEntry]) -> list[str]:
+    """Advance every DecayingValue entry by one tick.
+
+    Adapters (or the listener) call this when a tick event occurs.
+    Returns the names of variables that crossed from a positive value
+    to zero this tick — useful as a strong handler-firing trigger.
+    """
+    reached_zero: list[str] = []
+    for name, entry in symtab.items():
+        if isinstance(entry.value, DecayingValue):
+            was_positive = entry.value.current_value > 0.0
+            entry.value.tick()
+            if was_positive and entry.value.current_value == 0.0:
+                reached_zero.append(name)
+    return reached_zero
+
+
 def _exec_combine(node: CombineNode, symtab: dict[str, SymbolEntry]) -> list[str]:
     entry = symtab[node.target.name]
     total = sum(entry.value)
@@ -1226,7 +1278,10 @@ def _evaluate_expression(
         # If the word matches a symbol, copy its value (§24 line 486).
         # Otherwise treat the word as a string literal.
         if expr.word in symtab:
-            return copy.deepcopy(symtab[expr.word].value)
+            val = symtab[expr.word].value
+            if isinstance(val, DecayingValue):
+                return val.current_value
+            return copy.deepcopy(val)
         return expr.word
     if isinstance(expr, QuotedString):
         # v2c §86/§87 — quoted content is always a literal string. No
@@ -1234,7 +1289,10 @@ def _evaluate_expression(
         return expr.content
     if isinstance(expr, NameRef):
         if expr.name in symtab:
-            return copy.deepcopy(symtab[expr.name].value)
+            val = symtab[expr.name].value
+            if isinstance(val, DecayingValue):
+                return val.current_value
+            return copy.deepcopy(val)
         raise _RuntimeError(
             f"I can't find '{expr.name}'. You might need to 'remember' it first."
         )
@@ -1375,7 +1433,10 @@ def _eval_field(field_node: ASTNode, current_item: Any, symtab) -> Any:
         if isinstance(current_item, dict) and field_node.name in current_item:
             return current_item[field_node.name]
         if field_node.name in symtab:
-            return symtab[field_node.name].value
+            val = symtab[field_node.name].value
+            if isinstance(val, DecayingValue):
+                return val.current_value
+            return val
         raise _RuntimeError(
             f"I can't find '{field_node.name}' in this item."
         )
@@ -1393,7 +1454,10 @@ def _eval_value(value_node: ASTNode, current_item: Any, symtab) -> Any:
         return value_node.value
     if isinstance(value_node, BareWord):
         if value_node.word in symtab:
-            return symtab[value_node.word].value
+            val = symtab[value_node.word].value
+            if isinstance(val, DecayingValue):
+                return val.current_value
+            return val
         return value_node.word
     if isinstance(value_node, QuotedString):
         # v2c §86/§87 — quoted value is always a literal string.
@@ -1461,7 +1525,22 @@ def _store(
     (e.g. `source` in `remember a source called readme`). Only the
     `remember` exec paths pass this; interpreter-internal stores
     (gather, pack verb writes, add) leave it None.
+
+    Metabolic Era batch 1: if the existing entry's value is a
+    DecayingValue and the new value is numeric, this is a
+    reinforcement — reset ticks_elapsed and replace initial_value
+    while preserving the period. A non-numeric overwrite discards
+    the decay wrapper entirely.
     """
+    existing = symtab.get(name)
+    if (
+        existing is not None
+        and isinstance(existing.value, DecayingValue)
+        and isinstance(value, (int, float))
+        and not isinstance(value, bool)
+    ):
+        existing.value.reinforce(float(value))
+        return
     value = copy.deepcopy(value)
     type_, schema = _infer_type_and_schema(value)
     symtab[name] = SymbolEntry(
@@ -1471,6 +1550,8 @@ def _store(
 
 
 def _infer_type_and_schema(v: Any) -> tuple[str, dict[str, str] | None]:
+    if isinstance(v, DecayingValue):
+        return "number", None
     if isinstance(v, bool):
         return "number", None  # v1 has no bools; defensive
     if isinstance(v, (int, float)):
@@ -1513,6 +1594,8 @@ def _scalar_type(v: Any) -> str:
 
 def _display_lines(v: Any) -> list[str]:
     """Format a value as output lines per v1b §42."""
+    if isinstance(v, DecayingValue):
+        return [_format_scalar(v.current_value)]
     if isinstance(v, list) and v and isinstance(v[0], dict):
         # List of records: one record per line.
         return [_format_record(r) for r in v]

--- a/src/liminate/listener.py
+++ b/src/liminate/listener.py
@@ -45,7 +45,9 @@ from .interpreter import (
     _RuntimeError,
     _in_action_block,
     _live_value_names_ctx,
+    decay_tick,
 )
+from .vocabulary import DecayingValue
 from .parser import (
     ASTNode,
     CompoundConditionNode,
@@ -172,6 +174,34 @@ class _Runner:
         for adapter in self.adapters:
             adapter.stop()
         yield self._shutdown_adapter_complete()
+
+    # -------------------------------------------------------------------
+    # Metabolic Era batch 1 — decay tick driver
+    # -------------------------------------------------------------------
+
+    def tick_decay(self) -> Iterator[LiminateResult]:
+        """Advance every DecayingValue entry by one tick, then fire any
+        handlers whose compound eligibility transitioned false → true.
+
+        Treats every decaying name as `modified` for the cascade so that
+        handlers watching those names are re-evaluated on edge.
+        """
+        decaying = [
+            name for name, e in self.symtab.items()
+            if isinstance(e.value, DecayingValue)
+        ]
+        if not decaying:
+            return
+        decay_tick(self.symtab)
+        new_values = {
+            n: self.symtab[n].value.current_value for n in decaying
+        }
+        yield from self._fire_eligible(
+            modified_names=decaying,
+            new_values=new_values,
+            source="decay_tick",
+            cascade_chain=frozenset(),
+        )
 
     # -------------------------------------------------------------------
     # Initial evaluation (§121)
@@ -482,7 +512,10 @@ class _Runner:
                 return node.word  # bare word literal fallback
             if self.live_value_registry.is_unset(node.word):
                 return _UNSET
-            return entry.value
+            val = entry.value
+            if isinstance(val, DecayingValue):
+                return val.current_value
+            return val
         if isinstance(node, NameRef):
             entry = self.symtab.get(node.name)
             if entry is None:
@@ -491,7 +524,10 @@ class _Runner:
                 return _UNSET
             if self.live_value_registry.is_unset(node.name):
                 return _UNSET
-            return entry.value
+            val = entry.value
+            if isinstance(val, DecayingValue):
+                return val.current_value
+            return val
         if isinstance(node, FieldAccessNode):
             entry = self.symtab.get(node.record_name)
             if entry is None:

--- a/src/liminate/parser.py
+++ b/src/liminate/parser.py
@@ -316,6 +316,17 @@ class RemoveNode(ASTNode):
 
 
 @dataclass
+class WeakensNode(ASTNode):
+    """Metabolic Era batch 1 — autonomous linear decay verb.
+
+    `subject` is a NameRef to an existing numeric variable. `period` is
+    a NumberLiteral — the decay period in abstract ticks.
+    """
+    subject: NameRef
+    period: NumberLiteral
+
+
+@dataclass
 class FinishNode(ASTNode):
     """v3a §112 — exit listener mode immediately and totally.
 
@@ -676,6 +687,8 @@ def _parse_verb_statement(stream: TokenStream, comp: set[str]) -> ASTNode:
         return _parse_add(stream)
     if verb.value == "remove":
         return _parse_remove(stream)
+    if verb.value == "weakens":
+        return _parse_weakens(stream)
     if verb.value == "finish":
         # v3a §112 — slot-less verb. Phase 1 semantic check (in the
         # analyzer) rejects calls outside an action-block context; here
@@ -1251,6 +1264,42 @@ def _parse_remove(stream: TokenStream) -> RemoveNode:
     _consume_optional_article(stream)
     target = _consume_target(stream, verb="remove")
     return RemoveNode(item=item, target=target)
+
+
+# ---------------------------------------------------------------------------
+# weakens (Metabolic Era batch 1)
+# ---------------------------------------------------------------------------
+
+
+def _parse_weakens(stream: TokenStream) -> WeakensNode:
+    """`weakens [article]? <subject-name> over <number>`."""
+    _consume_optional_article(stream)
+    if stream.at_end():
+        raise _ParseError(
+            "'weakens' needs a target and a decay period — try: "
+            "weakens <name> over <number>."
+        )
+    subject = _consume_target(stream, verb="weakens")
+
+    over_tok = stream.consume()
+    if not (
+        over_tok
+        and over_tok.type is TokenType.CONNECTIVE
+        and over_tok.value == "over"
+    ):
+        raise _ParseError(
+            "'weakens' needs a decay period — try: "
+            "weakens <name> over <number>."
+        )
+
+    period_tok = stream.consume()
+    if not (period_tok and period_tok.type is TokenType.NUMBER):
+        raise _ParseError(
+            "I expected a number after 'over' — the decay period. "
+            "Try: weakens <name> over 30."
+        )
+    period = NumberLiteral(value=_parse_number(period_tok.value))
+    return WeakensNode(subject=subject, period=period)
 
 
 # ---------------------------------------------------------------------------

--- a/src/liminate/renderer.py
+++ b/src/liminate/renderer.py
@@ -51,6 +51,7 @@ from .parser import (
     RememberValueNode,
     SequenceNode,
     ShowNode,
+    WeakensNode,
     WhenNode,
 )
 from .vocabulary import ALL_RESERVED
@@ -178,6 +179,12 @@ def render(node: ASTNode) -> str:
     if isinstance(node, RemoveNode):
         # Canonical form: `remove <item> from <list>`.
         return f"remove {render(node.item)} from {node.target.name}"
+    if isinstance(node, WeakensNode):
+        # Metabolic Era batch 1 — `weakens <subject> over <period>`.
+        return (
+            f"weakens {node.subject.name} "
+            f"over {_fmt_number(node.period.value)}"
+        )
 
     if isinstance(node, PackVerbNode):
         # v4a §137 + v2: pack verbs render as `<word> [<conn>] <value>...`

--- a/src/liminate/vocabulary.py
+++ b/src/liminate/vocabulary.py
@@ -56,6 +56,10 @@ VERBS: frozenset[str] = frozenset({
     "remember", "show", "filter", "keep",
     "count", "gather", "combine", "each",
     "choose", "finish", "add", "remove",
+    # Metabolic Era batch 1: autonomous linear decay verb. Attaches
+    # decay metadata to an existing numeric variable; the value falls
+    # linearly to zero over a stated period (in abstract ticks).
+    "weakens",
 })
 
 # v1 / v2a / v2d / v3a connectives. v2a §68 added `of`. v2d §99 added
@@ -66,6 +70,8 @@ VERBS: frozenset[str] = frozenset({
 CONNECTIVES: frozenset[str] = frozenset({
     "where", "and", "or", "from", "with", "called", "to", "how", "as", "of",
     "if", "otherwise", "when", "unless", "includes", "within",
+    # Metabolic Era batch 1: introduces the decay period in `weakens`.
+    "over",
 })
 
 # v1 single-word operators (inception §11). `equal to` is a multi-word
@@ -97,11 +103,14 @@ V2_RESERVED: frozenset[str] = frozenset({
 # dependent on what word follows (v1a §29, v1c §47).
 MULTI_WORD_RESERVED: frozenset[str] = frozenset({"equal"})
 
-# All 38 reserved words. v3a §124 was 34 (+1 for `finish`). Liminate
-# `add` verb addendum v1 §9: +1 for `add` (appends an item to a list).
-# `includes` connective + `remove` verb addendum: +2 (list membership
-# test in conditions, retract item from a list). `within` connective: +1
-# (numeric tolerance for the session pack's `measure` verb).
+# All 40 reserved words. 13 verbs, 17 connectives. v3a §124 was 34
+# (+1 for `finish`). Liminate `add` verb addendum v1 §9: +1 for `add`
+# (appends an item to a list). `includes` connective + `remove` verb
+# addendum: +2 (list membership test in conditions, retract item from a
+# list). `within` connective: +1 (numeric tolerance for the session
+# pack's `measure` verb). Metabolic Era batch 1: +2 — `weakens` verb
+# (autonomous linear decay) and `over` connective (introduces the decay
+# period).
 ALL_RESERVED: frozenset[str] = (
     VERBS | CONNECTIVES | OPERATORS | ARTICLES | V2_RESERVED | MULTI_WORD_RESERVED
 )
@@ -301,4 +310,48 @@ VERB_SIGNATURES: dict[str, list[str]] = {
     "add":      ["item", "target"],
     # `remove` — retract an item from an existing list.
     "remove":   ["item", "target"],
+    # Metabolic Era batch 1: `weakens <subject> over <period>`.
+    "weakens":  ["subject", "schedule"],
 }
+
+
+# ---------------------------------------------------------------------------
+# Metabolic Era — autonomous linear decay value
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DecayingValue:
+    """A numeric value with autonomous linear decay.
+
+    Created by the `weakens` verb. The current value is computed on
+    read as: max(0.0, initial_value - (initial_value / period) * ticks_elapsed).
+    Floor at 0.0 — value never goes negative.
+
+    `remember` (i.e. `_store`) on a DecayingValue with a new numeric
+    value resets: ticks_elapsed → 0, initial_value → new value, period
+    preserved. That is the reinforcement mechanic.
+    """
+    initial_value: float
+    period: int | float
+    ticks_elapsed: int = 0
+
+    @property
+    def current_value(self) -> float:
+        if self.period <= 0:
+            return 0.0
+        decayed = (
+            self.initial_value
+            - (self.initial_value / self.period) * self.ticks_elapsed
+        )
+        return max(0.0, decayed)
+
+    def tick(self) -> None:
+        """Advance one tick. No-op once the value has reached the floor."""
+        if self.current_value > 0.0:
+            self.ticks_elapsed += 1
+
+    def reinforce(self, new_value: float) -> None:
+        """Reset decay with a new initial value. Period preserved."""
+        self.initial_value = float(new_value)
+        self.ticks_elapsed = 0

--- a/tests/test_vocabulary.py
+++ b/tests/test_vocabulary.py
@@ -17,25 +17,24 @@ from liminate.vocabulary import (
 
 
 def test_verb_count():
-    # 12 verbs: 11 (Liminate `add` v1 §9) + 1 (`remove` — retract an
-    # item from a list).
-    assert len(VERBS) == 12
+    # 13 verbs: 12 + 1 (`weakens` — autonomous linear decay).
+    assert len(VERBS) == 13
     assert VERBS == {
         "remember", "show", "filter", "keep", "count",
-        "gather", "combine", "each", "choose", "finish", "add", "remove",
+        "gather", "combine", "each", "choose", "finish",
+        "add", "remove", "weakens",
     }
 
 
 def test_connective_count():
-    # 16 connectives: v3a §124 had 14; `includes` adds list-membership for
-    # conditions; `within` introduces the tolerance value in the session
-    # pack's `measure` verb.
-    assert len(CONNECTIVES) == 16
+    # 17 connectives: 16 + 1 (`over` — introduces the decay period in
+    # the `weakens` verb).
+    assert len(CONNECTIVES) == 17
     assert CONNECTIVES == {
         "where", "and", "or", "from", "with",
         "called", "to", "how", "as", "of",
         "if", "otherwise",
-        "when", "unless", "includes", "within",
+        "when", "unless", "includes", "within", "over",
     }
 
 
@@ -67,11 +66,10 @@ def test_multi_word_reserved():
     assert MULTI_WORD_RESERVED == {"equal"}
 
 
-def test_total_reserved_count_is_38():
-    # 38 reserved words total. Delta from 37: +1 `within` connective for
-    # the session pack's `measure` verb. 12 verbs + 16 connectives
-    # + 4 operators + 1 multi-word + 3 articles + 2 v2-deferred verbs = 38.
-    assert len(ALL_RESERVED) == 38
+def test_total_reserved_count_is_40():
+    # 40 reserved words total. 13 verbs + 17 connectives + 4 operators
+    # + 1 multi-word + 3 articles + 2 v2-deferred verbs = 40.
+    assert len(ALL_RESERVED) == 40
 
 
 def test_reserved_sets_are_disjoint():
@@ -127,6 +125,8 @@ def test_verb_signature_slot_shapes():
     assert VERB_SIGNATURES["add"] == ["item", "target"]
     # `remove` — retract an item from an existing list (same slot shape).
     assert VERB_SIGNATURES["remove"] == ["item", "target"]
+    # Metabolic Era batch 1: `weakens <subject> over <period>`.
+    assert VERB_SIGNATURES["weakens"] == ["subject", "schedule"]
 
 
 def test_add_is_classified_as_verb():

--- a/tests/test_weakens.py
+++ b/tests/test_weakens.py
@@ -1,0 +1,335 @@
+"""Metabolic Era batch 1 — tests for the `weakens` verb + `over` connective.
+
+Covers parsing, analysis, execution (decay wrapping, tick advancement,
+floor at zero, reinforcement via `remember`, last-wins reapplication),
+display, and condition evaluation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from liminate.analyzer import SymbolEntry
+from liminate.interpreter import (
+    HandlerTable,
+    decay_tick,
+    execute as _execute,
+)
+from liminate.lexer import tokenize
+from liminate.listener import listen
+from liminate.parser import (
+    NameRef,
+    NumberLiteral,
+    WeakensNode,
+    parse,
+    parse_when_block,
+)
+from liminate.renderer import render
+from liminate.reorderer import reorder
+from liminate.result import LiminateResult, ResultStatus
+from liminate.adapter import LiveValueRegistry
+from liminate.vocabulary import DecayingValue
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse(line: str):
+    toks = tokenize(line)
+    reordered = reorder(toks)
+    if isinstance(reordered, LiminateResult):
+        return reordered
+    return parse(reordered)
+
+
+def run(line: str, symtab: dict[str, SymbolEntry] | None = None) -> LiminateResult:
+    if symtab is None:
+        symtab = {}
+    ast = _parse(line)
+    if isinstance(ast, LiminateResult):
+        return ast
+    return _execute(ast, symtab)
+
+
+# ---------------------------------------------------------------------------
+# DecayingValue arithmetic
+# ---------------------------------------------------------------------------
+
+
+def test_decaying_value_initial_value():
+    assert DecayingValue(1.0, 10).current_value == 1.0
+
+
+def test_decaying_value_at_end_of_period():
+    assert DecayingValue(1.0, 10, ticks_elapsed=10).current_value == 0.0
+
+
+def test_decaying_value_midway():
+    assert DecayingValue(1.0, 10, ticks_elapsed=5).current_value == 0.5
+
+
+def test_decaying_value_floors_at_zero():
+    v = DecayingValue(1.0, 10, ticks_elapsed=999)
+    assert v.current_value == 0.0
+
+
+def test_decaying_value_tick_stops_at_floor():
+    v = DecayingValue(1.0, 2)
+    v.tick()  # ticks_elapsed=1, value=0.5
+    v.tick()  # ticks_elapsed=2, value=0.0
+    v.tick()  # no-op once at floor
+    assert v.ticks_elapsed == 2
+    assert v.current_value == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+
+def test_parses_basic_weakens():
+    ast = _parse("weakens urgency over 30")
+    assert isinstance(ast, WeakensNode)
+    assert ast.subject == NameRef(name="urgency")
+    assert ast.period == NumberLiteral(value=30)
+
+
+def test_parses_with_article():
+    ast = _parse("weakens the urgency over 30")
+    assert isinstance(ast, WeakensNode)
+    assert ast.subject.name == "urgency"
+    assert ast.period.value == 30
+
+
+def test_parse_missing_target():
+    r = _parse("weakens over 30")
+    assert isinstance(r, LiminateResult)
+    assert r.status is ResultStatus.ERROR_PARSE
+
+
+def test_parse_missing_period():
+    r = _parse("weakens urgency")
+    assert isinstance(r, LiminateResult)
+    assert r.status is ResultStatus.ERROR_PARSE
+    assert "decay period" in r.message
+
+
+def test_parse_missing_number_after_over():
+    r = _parse("weakens urgency over")
+    assert isinstance(r, LiminateResult)
+    assert r.status is ResultStatus.ERROR_PARSE
+    assert "number" in r.message
+
+
+def test_parse_non_number_after_over():
+    r = _parse("weakens urgency over fast")
+    assert isinstance(r, LiminateResult)
+    assert r.status is ResultStatus.ERROR_PARSE
+
+
+# ---------------------------------------------------------------------------
+# Renderer round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_render_integer_period():
+    node = WeakensNode(subject=NameRef("urgency"), period=NumberLiteral(30))
+    assert render(node) == "weakens urgency over 30"
+
+
+def test_render_round_trip():
+    original = WeakensNode(subject=NameRef("priority"), period=NumberLiteral(7))
+    rendered = render(original)
+    reparsed = _parse(rendered)
+    assert reparsed == original
+
+
+# ---------------------------------------------------------------------------
+# Analyzer / executor — error paths
+# ---------------------------------------------------------------------------
+
+
+def test_analyzer_rejects_non_numeric_target():
+    symtab: dict[str, SymbolEntry] = {}
+    run('remember a label called my-name with "alice"', symtab)
+    r = run("weakens my-name over 10", symtab)
+    assert r.status is ResultStatus.ERROR_SEMANTIC
+    assert "only works on numbers" in r.message
+
+
+def test_analyzer_rejects_missing_target():
+    r = run("weakens nonexistent over 10")
+    assert r.status is ResultStatus.ERROR_SEMANTIC
+    assert "can't find" in r.message
+
+
+def test_analyzer_rejects_zero_period():
+    symtab: dict[str, SymbolEntry] = {}
+    run("remember a value called urgency with 1.0", symtab)
+    r = run("weakens urgency over 0", symtab)
+    assert r.status is ResultStatus.ERROR_SEMANTIC
+    assert "positive number" in r.message
+
+
+def test_analyzer_rejects_negative_period():
+    r = _parse("weakens urgency over -5")
+    # Lexer/reorderer may reject negatives at tokenization level; verify
+    # at least that this never becomes a successful WeakensNode at value
+    # <= 0. If the number is parsed, the analyzer fires.
+    if isinstance(r, WeakensNode):
+        assert r.period.value < 0
+
+
+def test_over_is_reserved_as_name():
+    r = run("remember a value called over with 5")
+    assert r.status is ResultStatus.ERROR_PARSE
+    assert "reserved" in r.message
+
+
+# ---------------------------------------------------------------------------
+# Execution — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_weakens_wraps_value_in_decaying_value():
+    symtab: dict[str, SymbolEntry] = {}
+    run("remember a value called urgency with 1.0", symtab)
+    r = run("weakens urgency over 10", symtab)
+    assert r.status is ResultStatus.SUCCESS
+    assert isinstance(symtab["urgency"].value, DecayingValue)
+    assert symtab["urgency"].value.initial_value == 1.0
+    assert symtab["urgency"].value.period == 10
+    assert symtab["urgency"].type == "number"
+
+
+def test_show_decaying_value_returns_current():
+    symtab: dict[str, SymbolEntry] = {}
+    run("remember a value called urgency with 1.0", symtab)
+    run("weakens urgency over 10", symtab)
+    r = run("show urgency", symtab)
+    assert r.output == ["1"]
+
+
+def test_show_after_five_ticks():
+    symtab: dict[str, SymbolEntry] = {}
+    run("remember a value called urgency with 1.0", symtab)
+    run("weakens urgency over 10", symtab)
+    for _ in range(5):
+        decay_tick(symtab)
+    r = run("show urgency", symtab)
+    assert r.output == ["0.5"]
+
+
+def test_show_at_floor():
+    symtab: dict[str, SymbolEntry] = {}
+    run("remember a value called urgency with 1.0", symtab)
+    run("weakens urgency over 10", symtab)
+    for _ in range(15):
+        decay_tick(symtab)
+    r = run("show urgency", symtab)
+    assert r.output == ["0"]
+
+
+def test_reinforcement_via_remember_resets_decay():
+    symtab: dict[str, SymbolEntry] = {}
+    run("remember a value called urgency with 1.0", symtab)
+    run("weakens urgency over 10", symtab)
+    for _ in range(7):
+        decay_tick(symtab)
+    run("remember a value called urgency with 0.8", symtab)
+    r = run("show urgency", symtab)
+    assert r.output == ["0.8"]
+    # Still a DecayingValue with the same period.
+    assert isinstance(symtab["urgency"].value, DecayingValue)
+    assert symtab["urgency"].value.period == 10
+    assert symtab["urgency"].value.ticks_elapsed == 0
+
+
+def test_reapplication_resets_from_current_value_and_new_period():
+    symtab: dict[str, SymbolEntry] = {}
+    run("remember a value called urgency with 1.0", symtab)
+    run("weakens urgency over 10", symtab)
+    for _ in range(5):
+        decay_tick(symtab)
+    # Now value is 0.5. Reapply with new period 5.
+    run("weakens urgency over 5", symtab)
+    dv = symtab["urgency"].value
+    assert isinstance(dv, DecayingValue)
+    assert dv.initial_value == 0.5
+    assert dv.period == 5
+    assert dv.ticks_elapsed == 0
+
+
+def test_non_numeric_remember_discards_decay_wrapper():
+    symtab: dict[str, SymbolEntry] = {}
+    run("remember a value called urgency with 1.0", symtab)
+    run("weakens urgency over 10", symtab)
+    r = run('remember a status called urgency with "cancelled"', symtab)
+    assert r.status is ResultStatus.SUCCESS
+    assert symtab["urgency"].value == "cancelled"
+    assert symtab["urgency"].type == "string"
+
+
+# ---------------------------------------------------------------------------
+# Condition evaluation reads decayed value
+# ---------------------------------------------------------------------------
+
+
+def test_filter_condition_against_decaying_value():
+    symtab: dict[str, SymbolEntry] = {}
+    run("remember a value called threshold with 1.0", symtab)
+    run("weakens threshold over 10", symtab)
+    run("remember a list called numbers with 1 and 2 and 3", symtab)
+    for _ in range(8):
+        decay_tick(symtab)
+    # threshold's current value should now be 0.2 — filter numbers above
+    # threshold should keep all of them.
+    r = run("filter the numbers where each is above threshold", symtab)
+    assert r.status is ResultStatus.SUCCESS
+    assert symtab["numbers"].value == [1, 2, 3]
+
+
+# ---------------------------------------------------------------------------
+# Listener integration — handler fires on decay crossing
+# ---------------------------------------------------------------------------
+
+
+def _build_when_node(header: str, *actions: str):
+    htoks = reorder(tokenize(header))
+    atoks = [reorder(tokenize(a)) for a in actions]
+    ast = parse_when_block(htoks, atoks)
+    assert not isinstance(ast, LiminateResult), ast
+    return ast
+
+
+def test_listener_eval_operand_unwraps_decaying_value():
+    """A `when` handler whose condition is `urgency is below 0.3`
+    should fire after enough ticks push the decayed value below 0.3."""
+    symtab: dict[str, SymbolEntry] = {}
+    run("remember a value called urgency with 1.0", symtab)
+    run("weakens urgency over 10", symtab)
+
+    ht = HandlerTable()
+    reg = LiveValueRegistry()
+    when_ast = _build_when_node(
+        "when urgency is below 0.3",
+        'show "urgency faded"',
+    )
+    _execute(when_ast, symtab, handler_table=ht, live_value_registry=reg)
+
+    # Drive 8 ticks (urgency = 0.2), then fire eligible handlers.
+    from liminate.listener import _Runner
+    runner = _Runner(symtab, ht, reg, adapters=[])
+    # Initial eligibility = false (1.0 not below 0.3).
+    list(runner._initial_evaluation())
+    assert ht.handlers[0].last_eligibility is False
+
+    for _ in range(8):
+        decay_tick(symtab)
+    fires = list(runner.tick_decay())
+    fire_outputs = [r.output for r in fires if r.status is ResultStatus.HANDLER_FIRE]
+    assert any(
+        out == ["urgency faded"] for out in fire_outputs
+    ), f"expected handler to fire, got: {fires}"


### PR DESCRIPTION
## Summary

Metabolic Era batch 1: introduces autonomous linear decay to Liminate.

- **`weakens`** (13th base verb) — attaches decay metadata to a numeric variable.
- **`over`** (17th base connective) — introduces the decay period.
- Shape: `weakens [article]? <subject-name> over <number>`.
- Linear decay to zero with floor at `0.0`; ticks advanced by `decay_tick(symtab)` (callable from adapters) or `_Runner.tick_decay()` in listener mode.
- `remember <name> with <new-numeric>` on a decaying value is **reinforcement** (ticks reset, period preserved). A non-numeric overwrite discards the wrapper.
- Reapplying `weakens` is **last-wins** (current decayed value becomes new initial, new period takes effect, ticks reset).

## Phases completed
1. Vocabulary — `weakens`/`over` registered; `DecayingValue` dataclass; counts updated.
2. Parser — `WeakensNode` AST + `_parse_weakens` + dispatch.
3. Analyzer — `_check_weakens`: live-value rejection, symbol-table presence, numeric type, positive period; side-effect classification.
4. Interpreter — `_exec_weakens`, `decay_tick()` exported, DecayingValue unwrapping in `_evaluate_expression`/`_eval_field`/`_eval_value`/`_display_lines`/`_infer_type_and_schema`; `_store` reinforcement path.
5. Renderer — `WeakensNode` canonical form; round-trip verified.
6. Listener — DecayingValue unwrap in `_eval_operand`; new `_Runner.tick_decay()` for adapters/drivers.
7. Tests — 27 new tests in `tests/test_weakens.py`; counts in `tests/test_vocabulary.py` updated to 13/17/40.
8. Example — `examples/dogfood_weakens_decay.limn`.

## Files modified
- `src/liminate/vocabulary.py`
- `src/liminate/parser.py`
- `src/liminate/analyzer.py`
- `src/liminate/interpreter.py`
- `src/liminate/renderer.py`
- `src/liminate/listener.py`
- `tests/test_vocabulary.py`

## Files created
- `tests/test_weakens.py`
- `examples/dogfood_weakens_decay.limn`

## Invariants satisfied (§11)
- `len(VERBS) == 13`, `len(CONNECTIVES) == 17`, `len(ALL_RESERVED) == 40` everywhere.
- DecayingValue unwrapping at every symbol-table read site (interpreter + listener).
- Renderer round-trip holds: `parse(tokenize(render(WeakensNode))) == WeakensNode`.
- `_apply_op` copies untouched — unwrapping happens upstream of comparison.
- `_store` reinforcement guarded by `isinstance(value, (int, float)) and not isinstance(value, bool)`.

## New reserved word count
40 total — 13 verbs, 17 connectives, 4 operators, 1 multi-word, 3 articles, 2 v2-deferred verbs.

## Test plan
- [x] `pytest tests/` → 888 passed (was 861).
- [x] `pytest tests/test_weakens.py -v` → 27 passed.
- [x] `pytest tests/test_vocabulary.py -v` → 18 passed (counts updated).
- [x] `python3 -m liminate examples/dogfood_weakens_decay.limn --quiet` → runs cleanly; emits initial `urgency=1` and enters listener mode.
- [x] Manual gate confirmed (Rob).

🤖 Generated with [Claude Code](https://claude.com/claude-code)