### PR TITLE
docs: propagate assign/expect (42 → 44 reserved words)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 Liminate is a prose-as-syntax programming language. The interpreter is a Python pipeline: lexer → reorderer → parser + renderer → analyzer → interpreter, with a Phase 2 event-driven listener layered on top.
 
-Current vocabulary: 13 verbs, 17 connectives, 40 reserved words. Domain packs may declare additional verbs and nouns via the pack-verb contract.
+Current vocabulary: 16 verbs, 18 connectives, 44 reserved words. Domain packs may declare additional verbs and nouns via the pack-verb contract.
 
 ## Critical Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 Liminate is a prose-as-syntax programming language. The interpreter is a Python pipeline: lexer → reorderer → parser + renderer → analyzer → interpreter, with a Phase 2 event-driven listener layered on top.
 
-Current vocabulary: 13 verbs, 17 connectives, 40 reserved words. Domain packs may declare additional verbs and nouns via the pack-verb contract.
+Current vocabulary: 16 verbs, 18 connectives, 44 reserved words. Domain packs may declare additional verbs and nouns via the pack-verb contract.
 
 ## Critical Rules
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The sentence is the program.
 
-Liminate is a programming language whose syntax is plain English. A small, bounded vocabulary of 40 reserved words combines into sentences that a real interpreter lexes, parses, type-checks, and runs. Not a prompt. Not a code generator. The prose IS the program.
+Liminate is a programming language whose syntax is plain English. A small, bounded vocabulary of 44 reserved words combines into sentences that a real interpreter lexes, parses, type-checks, and runs. Not a prompt. Not a code generator. The prose IS the program.
 
 ## What it does
 
@@ -67,7 +67,7 @@ pytest tests/
 
 ## How it works
 
-The current build is **v0.2.0**: 13 verbs, 17 connectives, 40 base reserved words, **888 tests passing** across 127 locked test sentences.
+The current build is **v0.2.0**: 16 verbs, 18 connectives, 44 base reserved words, **972 tests passing** across 127 locked test sentences.
 
 ### The pipeline
 
@@ -78,11 +78,11 @@ Two phases of execution:
 - **Phase 1 — sequential.** Each statement runs in order. Stepwise commit: if a later op fails, earlier side effects remain and the error names what was completed.
 - **Phase 2 — reactive listener.** `when`/`unless` register handlers driven by an external event source (a domain pack adapter). Edge-triggered, depth-first cascading, conservative same-handler-twice cycle detection. `finish` exits immediately and totally.
 
-### The vocabulary (40 words)
+### The vocabulary (44 words)
 
-**Verbs (13):** `remember`, `show`, `filter`, `keep`, `count`, `gather`, `combine`, `each`, `choose`, `finish`, `add`, `remove`, `weakens`.
+**Verbs (16):** `remember`, `show`, `filter`, `keep`, `count`, `gather`, `combine`, `each`, `choose`, `finish`, `add`, `remove`, `weakens`, `require`, `assign`, `expect`.
 
-**Connectives (17):** `where`, `and`, `or`, `from`, `with`, `called`, `to`, `how`, `as`, `of`, `if`, `otherwise`, `when`, `unless`, `includes`, `within`, `over`.
+**Connectives (18):** `where`, `and`, `or`, `from`, `with`, `called`, `to`, `how`, `as`, `of`, `if`, `otherwise`, `when`, `unless`, `includes`, `within`, `over`, `then`.
 
 **Operators (5):** `is`, `above`, `below`, `equal to`, `not`.
 
@@ -96,7 +96,7 @@ Two phases of execution:
 
 ### Domain packs
 
-A pack is a small JSON file that adds nouns and verbs while it's loaded. The base 40 words are permanent; pack-contributed words are reserved only when the pack is active.
+A pack is a small JSON file that adds nouns and verbs while it's loaded. The base 44 words are permanent; pack-contributed words are reserved only when the pack is active.
 
 A pack verb declares a slot signature, a type constraint, and one of five execution dispatches:
 
@@ -141,7 +141,7 @@ liminate --pack examples/pack_ui.json --quiet \
 liminate/
 ├── src/liminate/        Pipeline (lexer, reorderer, parser, renderer,
 │                        analyzer, interpreter, listener, adapter, packs/)
-├── tests/               888 tests across the 127 locked sentences
+├── tests/               972 tests across the 127 locked sentences
 ├── examples/            Runnable .limn programs + reference packs
 ├── docs/spec/           Locked specification documents
 └── docs/                Quickstart, syntax tour, pipeline walkthrough

--- a/docs/DEV_README.md
+++ b/docs/DEV_README.md
@@ -4,7 +4,7 @@ A prose-as-syntax programming language designed from the human end.
 
 > *"Every programming language in history was designed by programmers. This one wasn't. That's why the design is different."*
 
-**Status (May 19, 2026):** v1 interpreter + v2a (`keep`, `of`, multi-field `each show`, descriptor preservation) + UX polish (`--quiet`, named-offender errors, auto-show truncation) + v2.1-patches + v2b (composition return values, generalized `of`) + v2c (quoting mechanism for multi-word strings) + v2d (composition parameters with `from`, `choose` verb with `if`/`otherwise`) + v3a event-driven execution (`when`/`unless`/`finish`, two-phase listener model, single-threaded event queue, cascading triggers with cycle detection, domain-pack adapter contract) + v3b (quoted-string case preservation) + v4a pack verb contract (general-purpose JSON-defined pack verbs with slot signatures, type constraints, and execution dispatch; UI domain pack with 10 nouns + `navigate to <screen-name>`) + `add` verb addendum + `includes` connective / `remove` verb addendum + `within` connective with the session pack's `measure` verb + **Metabolic Era batch 1** (`weakens`/`over` — autonomous linear decay over a stated period of ticks). **888 tests passing.** The sequential feature set (v1 → v2d), the reactive feature set (v3a/v3b), the pack-verb extension contract, and the Metabolic Era's autonomous-time primitives together form a structurally complete programming language; pack verbs let domains add vocabulary without touching the base 40 reserved words.
+**Status (May 19, 2026):** v1 interpreter + v2a (`keep`, `of`, multi-field `each show`, descriptor preservation) + UX polish (`--quiet`, named-offender errors, auto-show truncation) + v2.1-patches + v2b (composition return values, generalized `of`) + v2c (quoting mechanism for multi-word strings) + v2d (composition parameters with `from`, `choose` verb with `if`/`otherwise`) + v3a event-driven execution (`when`/`unless`/`finish`, two-phase listener model, single-threaded event queue, cascading triggers with cycle detection, domain-pack adapter contract) + v3b (quoted-string case preservation) + v4a pack verb contract (general-purpose JSON-defined pack verbs with slot signatures, type constraints, and execution dispatch; UI domain pack with 10 nouns + `navigate to <screen-name>`) + `add` verb addendum + `includes` connective / `remove` verb addendum + `within` connective with the session pack's `measure` verb + **Metabolic Era batch 1** (`weakens`/`over` — autonomous linear decay over a stated period of ticks) + **Normative Era batch 2** (`require`/`then` — enforcement and declared sequencing) + **Delegated/Epistemic Era batch 3** (`assign`/`expect` — item-to-recipient delegation and non-halting tracked anticipation). **972 tests passing.** The sequential feature set (v1 → v2d), the reactive feature set (v3a/v3b), the pack-verb extension contract, the Metabolic Era's autonomous-time primitives, the Normative Era's enforcement-and-sequencing primitives, and the Delegated/Epistemic Era's delegation-and-anticipation primitives together form a structurally complete programming language; pack verbs let domains add vocabulary without touching the base 44 reserved words.
 
 ---
 
@@ -34,7 +34,7 @@ A prose-as-syntax programming language designed from the human end.
 
 `filter the orders where total is above 50` is not a prompt to an AI. It is the program.
 
-Liminate is a general-purpose programming language whose source code is readable English prose. A bounded vocabulary of 34 words combines into sentences that execute directly. There is no separate code the prose generates — the sentence IS the program.
+Liminate is a general-purpose programming language whose source code is readable English prose. A bounded vocabulary of 44 words combines into sentences that execute directly. There is no separate code the prose generates — the sentence IS the program.
 
 This is not a domain-specific language for queries or data, nor a natural-language layer over Python, nor a code-generating AI. It is a programming language with its own pipeline: lexer, reorderer, parser, semantic analyzer, interpreter. The prose-as-syntax constraint is structural, not cosmetic.
 
@@ -58,7 +58,7 @@ Five properties combine in Liminate that exist individually in other systems but
 
 1. **Prose-as-syntax where the prose IS the executable code.** Not prose that generates code (vibe coding). Not prose that describes a game world (Inform 7, which is domain-locked). General-purpose computation expressed as readable English sentences that execute directly.
 
-2. **Bounded vocabulary as design constraint.** 40 reserved words in the current build (13 verbs + 17 connectives + 4 single-word operators + `equal` as a multi-word component + 3 articles + 2 v2-deferred words). The vocabulary is the language boundary, not a starter set that grows. Expressiveness scales through domain packs, composition over expansion, and named-composition chunking — not through adding more keywords. 
+2. **Bounded vocabulary as design constraint.** 44 reserved words in the current build (16 verbs + 18 connectives + 4 single-word operators + `equal` as a multi-word component + 3 articles + 2 v2-deferred words). The vocabulary is the language boundary, not a starter set that grows. Expressiveness scales through domain packs, composition over expansion, and named-composition chunking — not through adding more keywords. 
 
 3. **Graduation from tiles to text within one language.** The same AST underlies a tile-composition surface (for first-encounter authoring), a prose surface (for fluent authoring), and an optional symbolic surface (for velocity). Three views, one structure. Scratch-to-Python is two languages; Liminate is one language with three surfaces. The v1 interpreter implements the prose surface; the tile surface is a separate downstream concern.
 
@@ -171,9 +171,9 @@ Every statement is echoed first in canonical prose form (the parser's interpreta
 
 ## The vocabulary
 
-The current base vocabulary is 40 reserved words across five categories. The complete list is the entire language surface — no other words are part of Liminate, only user-provided names and literal values. Domain packs may add their own verbs and nouns at runtime via the pack verb contract; pack-contributed words are reserved only while the pack is loaded, and the base 40 are permanent.
+The current base vocabulary is 44 reserved words across five categories. The complete list is the entire language surface — no other words are part of Liminate, only user-provided names and literal values. Domain packs may add their own verbs and nouns at runtime via the pack verb contract; pack-contributed words are reserved only while the pack is loaded, and the base 44 are permanent.
 
-### Verbs (13)
+### Verbs (16)
 
 | Verb | Purpose |
 |---|---|
@@ -190,8 +190,11 @@ The current base vocabulary is 40 reserved words across five categories. The com
 | `add` | Append an item to a list |
 | `remove` | Retract an item from a list |
 | `weakens` | Attach autonomous linear decay to a numeric value — falls to zero over a stated period of ticks |
+| `require` | Evaluate a condition; halt with `REQUIREMENT_NOT_MET` on failure (silent on pass) |
+| `assign` | Store an item-to-recipient mapping (`assign review-task to "compliance-team"`) |
+| `expect` | Evaluate a condition; emit a divergence output line on failure but continue with `SUCCESS` (informational, non-halting) |
 
-### Connectives (17)
+### Connectives (18)
 
 | Connective | Purpose |
 |---|---|
@@ -201,7 +204,7 @@ The current base vocabulary is 40 reserved words across five categories. The com
 | `from` | Range start; result capture; simple reference; composition parameter declaration and passing |
 | `with` | Introduces values, list items, or record fields |
 | `called` | Introduces a name |
-| `to` | Range endpoint, or component of `equal to` |
+| `to` | Range endpoint, or component of `equal to`, or recipient in `assign` |
 | `how` | Signals a named-composition definition (with `to`) |
 | `as` | Field assignment in records |
 | `of` | Single-record field access — `<field> of <record>` in any value position |
@@ -212,6 +215,7 @@ The current base vocabulary is 40 reserved words across five categories. The com
 | `includes` | List membership test in a condition (`where items includes "foo"`) |
 | `within` | Numeric tolerance band for the session pack's `measure` verb |
 | `over` | Introduces the decay period in `weakens` (`weakens energy over 10`) |
+| `then` | Declared sequencing between operations (`add ... then require ...`) — same level as `and` but with stated ordering intent |
 
 ### Operators (5)
 
@@ -482,9 +486,9 @@ Line 3 then shows `4, 5` — the filter's commit persists. Multi-operation seque
 
 ## Current scope and deferrals
 
-The shipped build covers v1 (48 locked test sentences) + v2a (11 more) + UX polish + v2.1-patches + v2b (9 more) + v2c (12 more) + v2d (15 more) + v3a (18 more) + v3b (4 more) + v4a (10 more). **713 tests passing.** Larger scope is intentionally deferred — but the sequential feature set (v1 → v2d), the reactive feature set (v3a/v3b), and the pack-verb extension contract together form a structurally complete programming language.
+The shipped build covers v1 (48 locked test sentences) + v2a (11 more) + UX polish + v2.1-patches + v2b (9 more) + v2c (12 more) + v2d (15 more) + v3a (18 more) + v3b (4 more) + v4a (10 more) plus the Metabolic / Normative / Delegated / Epistemic era batches (`weakens`/`over`, `require`/`then`, `assign`/`expect`). **972 tests passing.** Larger scope is intentionally deferred — but the sequential feature set (v1 → v2d), the reactive feature set (v3a/v3b), the pack-verb extension contract, and the era batches together form a structurally complete programming language.
 
-**Currently shipped.** Two-phase execution (Phase 1 sequential, Phase 2 reactive). 13 base verbs. 17 connectives. 40 base reserved words. Numbers (integers + decimals). Strings (single-token bare words + multi-word quoted strings via v2c, with verbatim case preservation per). Lists (homogeneous — all numbers, all strings, or all records). Records (named fields, with descriptor preserved on the symbol for pack-verb type checks). Named compositions with optional parameters. Conditional branching via `choose if/otherwise`. In-place `filter`, non-destructive `keep`, non-destructive `combine`, copy semantics, iterator context for `each`, multi-field display in `each ... show`, single-record field access via `show <field> of <record>` and `<field> of <record>` in any value position. Descriptor preservation, named-offender error wording, stepwise sequences. Composition return values via `remember the X from <comp>`. Event-driven `when`/`unless`/`finish` with indented action blocks, single-threaded event queue, edge-triggered evaluation with deep value equality, depth-first cascading with conservative cycle detection, domain-pack adapter contract registered externally via `--pack <path>` JSON or `Session(domain_packs=...)`. v4a general-purpose pack verb contract — packs declare verbs with slot signatures + type constraints + execution dispatch in JSON; the parser dispatches pack verbs after base verbs, the analyzer enforces descriptor-based type constraints, and `set_value` is the first execution type. The UI domain pack ships 10 component nouns and the `navigate to <screen-name>` verb. CLI flags `--quiet`, `--test`, `--pack` (any position).
+**Currently shipped.** Two-phase execution (Phase 1 sequential, Phase 2 reactive). 16 base verbs. 18 connectives. 44 base reserved words. Numbers (integers + decimals). Strings (single-token bare words + multi-word quoted strings via v2c, with verbatim case preservation per). Lists (homogeneous — all numbers, all strings, or all records). Records (named fields, with descriptor preserved on the symbol for pack-verb type checks). Named compositions with optional parameters. Conditional branching via `choose if/otherwise`. In-place `filter`, non-destructive `keep`, non-destructive `combine`, copy semantics, iterator context for `each`, multi-field display in `each ... show`, single-record field access via `show <field> of <record>` and `<field> of <record>` in any value position. Descriptor preservation, named-offender error wording, stepwise sequences. Composition return values via `remember the X from <comp>`. Event-driven `when`/`unless`/`finish` with indented action blocks, single-threaded event queue, edge-triggered evaluation with deep value equality, depth-first cascading with conservative cycle detection, domain-pack adapter contract registered externally via `--pack <path>` JSON or `Session(domain_packs=...)`. v4a general-purpose pack verb contract — packs declare verbs with slot signatures + type constraints + execution dispatch in JSON; the parser dispatches pack verbs after base verbs, the analyzer enforces descriptor-based type constraints, and `set_value` is the first execution type. The UI domain pack ships 10 component nouns and the `navigate to <screen-name>` verb. CLI flags `--quiet`, `--test`, `--pack` (any position).
 
 **Not built (deliberately).** Tile-composition interface. Proposal engine and authorize-don't-author authoring flow. Real-world domain packs (healthcare, smart home, game) — the language ships a test adapter only, packs are product work. Domain pack activation syntax (an Liminate-level `use`/`load` verb). The verbs `transform`, `compare` — reserved-word slots protected, no grammar yet. Symbolic syntax surface. External data sources beyond domain-pack adapters. Negative numbers. Scope isolation beyond the iterator context and composition parameters. Mixed-type lists. Descending ranges. Ranges over 10,000 items. Nested records (and therefore chained `of`). `choose` inside `each`. Sophisticated cycle detection beyond same-handler-twice. Adapter timeout or preemption. Tile interface, proposal engine, domain packs as product surfaces.
 
@@ -498,7 +502,7 @@ These are the load-bearing decisions that shape every implementation choice. Eac
 
 **The prose IS the program.** The interpreter operates exclusively on what the user stated. It does not infer, assume, guess, or fill in unstated information. If the prose doesn't say it, it doesn't happen.
 
-**The vocabulary is the boundary.** 40 reserved words in the current build. v2c added a quoting mechanism for multi-word string values, but only in value positions — names and field names still come from the unquoted name-space. Vocabulary words cannot appear unquoted as user-provided names or as string values. This is structurally why slot-filling parser logic works: every word's category is known in advance. Each addition to the vocabulary (v2a's `keep`, v2a's `of`, v2d's `choose`/`if`/`otherwise`, v3a's `when`/`unless`/`finish`, the `add`/`remove`/`includes`/`within` addenda, Metabolic Era's `weakens`/`over`) is the smallest spec change consistent with a dogfooded gap.
+**The vocabulary is the boundary.** 44 reserved words in the current build. v2c added a quoting mechanism for multi-word string values, but only in value positions — names and field names still come from the unquoted name-space. Vocabulary words cannot appear unquoted as user-provided names or as string values. This is structurally why slot-filling parser logic works: every word's category is known in advance. Each addition to the vocabulary (v2a's `keep`, v2a's `of`, v2d's `choose`/`if`/`otherwise`, v3a's `when`/`unless`/`finish`, the `add`/`remove`/`includes`/`within` addenda, Metabolic Era's `weakens`/`over`, Normative Era's `require`/`then`, Delegated/Epistemic Era's `assign`/`expect`) is the smallest spec change consistent with a dogfooded gap.
 
 **The reorderer does not guess.** When an arrangement of words could fill slots in more than one valid way, the system produces an amber clarification prompt rather than picking one interpretation. Authorship over inference.
 
@@ -634,7 +638,7 @@ The build is a paired collaboration. The architect produces and approves every d
 
 ## Status and what's next
 
-**Currently shipped.** v1 → v2d (sequential) + v3a/v3b (event-driven listener mode + quoted-string case preservation) + v4a (pack verb contract + UI domain pack). 713 tests passing. The interpreter runs in a terminal as text-only, reads `.limn` source files, and offers an interactive REPL with `--quiet`, `--test`, and `--pack` flags. A separate TypeScript port (lexer/reorderer/parser/analyzer/renderer — no interpreter) lives in the Möbius monorepo at `packages/liminate-lang/` and validates the same 127 sentences against this implementation as its sync contract.
+**Currently shipped.** v1 → v2d (sequential) + v3a/v3b (event-driven listener mode + quoted-string case preservation) + v4a (pack verb contract + UI domain pack) + Metabolic / Normative / Delegated / Epistemic era batches (`weakens`/`over`, `require`/`then`, `assign`/`expect`). 972 tests passing. The interpreter runs in a terminal as text-only, reads `.limn` source files, and offers an interactive REPL with `--quiet`, `--test`, and `--pack` flags. A separate TypeScript port (lexer/reorderer/parser/analyzer/renderer — no interpreter) lives in the Möbius monorepo at `packages/liminate-lang/` and validates the same 127 sentences against this implementation as its sync contract.
 
 **The largest remaining work is not language additions.** It's everything around the language — Future surfaces and domain packs as product surfaces. Specifically:
 

--- a/docs/handoffs/liminate_site_handoff_2026_05_19_assign_expect.md
+++ b/docs/handoffs/liminate_site_handoff_2026_05_19_assign_expect.md
@@ -1,0 +1,184 @@
+# Liminate Site Update — Handoff Packet
+
+**Date:** 2026-05-19
+**Source:** PR #9 in `rmichaelthomas/liminate` (merge commit `15fe966`) — "feat: add `assign`/`expect` — delegated + epistemic eras (42 → 44)". This is batch 3 in a vocabulary-strategy walkthrough that also added `weakens`/`over` (batch 1) and `require`/`then` (batch 2). The site is currently pinned to the **pre-batch-1** vocabulary numbers, so this handoff brings it forward across all three batches in one pass.
+**Scope:** Vocabulary expanded from **35 → 44 reserved words** (11 → 16 verbs, 14 → 18 connectives). The new verbs are `weakens`, `require`, `assign`, `expect`. The new connectives are `over`, `then`. The test count has grown from 835 → 972 pytest cases. The "139 locked test sentences" pill on the home page should be reviewed — the core repo's own README and DEV_README currently say "127 locked test sentences," so the site is ahead of the repo on this number. Flag with Rob; do not change autonomously.
+
+---
+
+## Pages Requiring Updates
+
+| Page | Path | What to change |
+|---|---|---|
+| Home (hero pills) | `index.html` | Three pills are stale: tests passing, the reserved-word count, and the verbs/connectives count. |
+| Spec / repos | `spec/index.html` | The "Interpreter repository" card's plain-English status sentence cites the reserved-word, test-sentence, and pytest-case numbers inline. Update the reserved-word and pytest counts; flag the 139-sentence number for Rob. |
+| Language | `language/index.html` | The page lede in both modes cites "35 reserved words"; tech mode also gives the verb/connective breakdown. Meta description and the vocabulary list item both repeat "35". |
+| Vocabulary | `language/vocabulary/index.html` | Page title, lede, meta description, and the verb-and-connective tables are all stuck at the pre-batch-1 enumeration. This is the largest single edit and should pick up the new four verbs and two connectives in the right cells. |
+
+---
+
+## Content Diffs
+
+### `index.html` (hero pills, around line 36–38)
+
+**Current text:**
+```html
+<span class="pill"><span data-plain>835 tests passing</span><span data-tech>835 pytest cases</span></span>
+<span class="pill"><span data-plain>139 locked test sentences</span><span data-tech>139 locked test sentences</span></span>
+<span class="pill"><span data-plain>35 reserved words</span><span data-tech>11 verbs, 14 connectives</span></span>
+```
+
+**Updated text:**
+```html
+<span class="pill"><span data-plain>972 tests passing</span><span data-tech>972 pytest cases</span></span>
+<span class="pill"><span data-plain>139 locked test sentences</span><span data-tech>139 locked test sentences</span></span>
+<span class="pill"><span data-plain>44 reserved words</span><span data-tech>16 verbs, 18 connectives</span></span>
+```
+
+Note: the "139 locked test sentences" pill is **not** changed in this diff. The core repo's README and DEV_README both say "127 locked test sentences" today, so the website is *ahead* of the source. Either the site pill was incremented in anticipation of new sentences that never got merged, or the README is behind. **Surface this to Rob as a question before changing.** Do not silently reconcile.
+
+### `spec/index.html` (Interpreter repository card, around line 33)
+
+**Current text:**
+```html
+<p data-plain>Status: v0.2.0. Current source has 35 reserved words, 139 locked test sentences, and 835 pytest cases.</p>
+```
+
+**Updated text:**
+```html
+<p data-plain>Status: v0.2.0. Current source has 44 reserved words, 139 locked test sentences, and 972 pytest cases.</p>
+```
+
+Same flag as above for "139 locked test sentences."
+
+### `language/index.html` (lede and list, lines 7, 31–34)
+
+**Current text (meta description, line 7):**
+```html
+<meta name="description" content="The language is bounded. Liminate begins with 35 reserved words; expressiveness comes from composition and domain packs.">
+```
+
+**Updated text:**
+```html
+<meta name="description" content="The language is bounded. Liminate begins with 44 reserved words; expressiveness comes from composition and domain packs.">
+```
+
+**Current text (lede + list, lines 31–34):**
+```html
+<p class="lede" data-plain>Liminate starts with 35 reserved words. Power comes from combining them, not from piling on more.</p>
+<p class="lede" data-tech>Liminate begins with 35 reserved words: 11 verbs, 14 connectives, 4 operators, 3 articles, 2 deferred reserved words, and the <code>equal</code> operator trigger.</p>
+<ul class="index-list">
+  <li><a href="vocabulary/">Vocabulary</a><span data-plain>The 35 words and what each kind does.</span><span data-tech>Verbs, connectives, operators, articles, future reserved words.</span></li>
+```
+
+**Updated text:**
+```html
+<p class="lede" data-plain>Liminate starts with 44 reserved words. Power comes from combining them, not from piling on more.</p>
+<p class="lede" data-tech>Liminate begins with 44 reserved words: 16 verbs, 18 connectives, 4 operators, 3 articles, 2 deferred reserved words, and the <code>equal</code> operator trigger.</p>
+<ul class="index-list">
+  <li><a href="vocabulary/">Vocabulary</a><span data-plain>The 44 words and what each kind does.</span><span data-tech>Verbs, connectives, operators, articles, future reserved words.</span></li>
+```
+
+### `language/vocabulary/index.html` (title, lede, meta, table)
+
+**Current text (meta description, line 7):**
+```html
+<meta name="description" content="Thirty-five reserved words. No other words are part of the base language except user-provided names and literal values.">
+```
+
+**Updated text:**
+```html
+<meta name="description" content="Forty-four reserved words. No other words are part of the base language except user-provided names and literal values.">
+```
+
+**Current text (page title, lines 30–31):**
+```html
+<h1 class="page-title" data-plain>Thirty-five reserved words.</h1>
+<h1 class="page-title" data-tech>Thirty-five reserved words.</h1>
+```
+
+**Updated text:**
+```html
+<h1 class="page-title" data-plain>Forty-four reserved words.</h1>
+<h1 class="page-title" data-tech>Forty-four reserved words.</h1>
+```
+
+**Current text (category table, lines 35–36):**
+```html
+<tr><td>Verbs</td><td><code>remember</code>, <code>show</code>, <code>filter</code>, <code>keep</code>, <code>count</code>, <code>gather</code>, <code>combine</code>, <code>each</code>, <code>choose</code>, <code>finish</code>, <code>add</code></td></tr>
+<tr><td>Connectives</td><td><code>where</code>, <code>and</code>, <code>or</code>, <code>from</code>, <code>with</code>, <code>called</code>, <code>to</code>, <code>how</code>, <code>as</code>, <code>of</code>, <code>if</code>, <code>otherwise</code>, <code>when</code>, <code>unless</code></td></tr>
+```
+
+**Updated text:**
+```html
+<tr><td>Verbs</td><td><code>remember</code>, <code>show</code>, <code>filter</code>, <code>keep</code>, <code>count</code>, <code>gather</code>, <code>combine</code>, <code>each</code>, <code>choose</code>, <code>finish</code>, <code>add</code>, <code>remove</code>, <code>weakens</code>, <code>require</code>, <code>assign</code>, <code>expect</code></td></tr>
+<tr><td>Connectives</td><td><code>where</code>, <code>and</code>, <code>or</code>, <code>from</code>, <code>with</code>, <code>called</code>, <code>to</code>, <code>how</code>, <code>as</code>, <code>of</code>, <code>if</code>, <code>otherwise</code>, <code>when</code>, <code>unless</code>, <code>includes</code>, <code>within</code>, <code>over</code>, <code>then</code></td></tr>
+```
+
+Verb ordering follows the order they appear in `src/liminate/vocabulary.py`'s `VERBS` frozenset — by inception batch — so new readers see the historical accretion. The new four (`remove`, `weakens`, `require`, `assign`, `expect`) sit at the end. Connectives likewise: `includes`, `within`, `over`, `then` go at the end.
+
+Note: this table also lists Operators / Articles / Future reserved / Syntax marker rows. Those rows are unchanged and should not be touched.
+
+---
+
+## What the new words mean (so the writer doesn't have to dig)
+
+The site's vocabulary page is currently terse — just the word lists, no per-word descriptions. That's fine; no per-word copy is required by this handoff. But for context, in case the writer wants to add a follow-up explainer page:
+
+| Word | Kind | One-line meaning |
+|---|---|---|
+| `remove` | verb | Retracts an item from a list (mirror of `add`; errors if not found). |
+| `weakens` | verb | Attaches autonomous linear decay to a numeric value — falls to zero over a stated period of ticks. |
+| `require` | verb | Evaluates a condition; halts with `REQUIREMENT_NOT_MET` if it fails (silent on pass). |
+| `assign` | verb | Stores an item-to-recipient mapping (`assign review-task to "compliance-team"`). |
+| `expect` | verb | Like `require`, but emits a divergence output line on failure and continues with `SUCCESS` — informational, non-halting. |
+| `over` | connective | Introduces the decay period in `weakens` (`weakens energy over 10`). |
+| `then` | connective | Declared sequencing between operations (`add ... then require ...`), same shape as `and` but with stated ordering intent. |
+
+These align with the "era" framing the architect has been using — `weakens` is Metabolic, `require`/`then` are Normative, `assign` is Delegated, `expect` is Epistemic. The site does not currently use that framing and **this handoff does not introduce it.** If a future explainer page wants to organize by era, that is a separate editorial decision.
+
+---
+
+## New Pages (if any)
+
+None for this propagation. The vocabulary expansion fits inside the existing page structure.
+
+---
+
+## Style and Tone Notes
+
+The liminate-site uses a **two-mode pattern** throughout: every prose paragraph has a `data-plain` (Plain English) version and a `data-tech` (Technical) version, toggled by a mode switch at the top of each page. When updating numbers, **always update both versions** — the diffs above already show both where they exist, but if you find another instance of the stale count, check for its sibling.
+
+The site's voice is deliberately understated. No exclamation marks, no marketing language ("powerful", "amazing", "revolutionary"). Phrases like "bounded vocabulary" and "the prose IS the program" are load-bearing — they appear repeatedly and shouldn't be paraphrased. The four-verb / two-connective addition is a quiet bump, not an announcement.
+
+Do not introduce any claim that isn't backed by the merged code. The era framing (Metabolic / Normative / Delegated / Epistemic) is internal architecture vocabulary — it exists in the core repo's DEV_README and commit messages but is not user-facing site copy.
+
+---
+
+## Do Not Change
+
+- Any pill, page, or paragraph that does not currently contain one of the stale numbers (`35`, `11`, `14`, `835`).
+- The "139 locked test sentences" pill on `index.html` and the equivalent in `spec/index.html` — flag for Rob first, since the core repo says 127.
+- The "two-mode" content infrastructure (`data-plain` / `data-tech` spans) — preserve the pattern exactly when editing.
+- The Operators / Articles / Future reserved / Syntax marker rows in the vocabulary table — unchanged by this propagation.
+- Any page under `learn/`, `philosophy/`, `start/`, `install/`, or `skills/` — none of those currently cite the vocabulary count, and the spot-check during repo scanning confirmed it.
+- Archival pages, historical references, or any content that names a prior locked count as historical context (none found, but flagged as a guard).
+
+---
+
+## Verification after the edits
+
+After applying the diffs, run:
+
+```bash
+grep -rEn "\b(35|11 verbs|14 connectives|835)\b" liminate-site/ \
+    --include="*.html" | grep -v "node_modules"
+```
+
+The output should be empty for the three numeric strings that appear in the diffs (`35`, `11 verbs`, `14 connectives`, `835`). If anything remains, it's drift this handoff missed — surface it.
+
+---
+
+## Provenance
+
+Generated by the `liminate-docs-propagation` skill on 2026-05-19, working from PR #9 (`feat/assign-expect-delegated-epistemic`, merged as `15fe966`) and a full scan of `~/liminate-site/` for the stale numeric strings. Counts cross-checked against `src/liminate/vocabulary.py` on `main` at the same commit: `len(VERBS) == 16`, `len(CONNECTIVES) == 18`, `len(ALL_RESERVED) == 44`. Test count is `pytest tests/` output on `main` post-merge.

--- a/docs/language/syntax.md
+++ b/docs/language/syntax.md
@@ -1,7 +1,7 @@
 # Liminate syntax
 
 A practical guide to writing Liminate programs. Liminate is a bounded
-prose language: 40 reserved words plus user-provided names and literal
+prose language: 44 reserved words plus user-provided names and literal
 values. The prose IS the program.
 
 This guide covers the full shipped surface: v1, v2a (`keep`, `of`,
@@ -43,7 +43,7 @@ three rules:
 
 - Start with a letter.
 - Contain letters, digits, and hyphens.
-- Cannot be one of the 40 reserved words.
+- Cannot be one of the 44 reserved words.
 
 Valid: `age`, `orders`, `find-big-orders`, `order1`, `my-list`.
 
@@ -310,6 +310,102 @@ filter the numbers where each is above 5
 and `filter` are list operations; per-record decisions live in the
 where-clause of a list operation, not in an `each` body. The error
 suggests the list-level alternative.
+
+### `add`
+
+Appends an item to an existing list.
+
+```
+add "new-task" to tasks
+add 42 to scores
+```
+
+The item is any value (number, string, bare word, or `<field> of
+<record>`). The target must be a list. The list's type is inferred on
+first add into an empty list; subsequent adds must match.
+
+### `remove`
+
+Retracts an item from an existing list. Mirror of `add`.
+
+```
+remove "old-task" from tasks
+```
+
+If the item is not in the list it is a runtime error — `remove` is
+explicit, not silent.
+
+### `weakens`
+
+Attaches autonomous linear decay to a numeric value. The value falls
+linearly to zero over the stated period (in abstract ticks). Reading
+the value at any point computes the current decayed amount.
+
+```
+remember a value called urgency with 1.0
+weakens urgency over 10
+```
+
+Re-assigning a number to a decaying value reinforces it — period
+preserved, decay restarted from the new initial value.
+
+### `require`
+
+Evaluates a condition. If it holds, execution continues silently. If
+it fails, the program halts with `REQUIREMENT_NOT_MET` and the error
+message echoes the condition and the actual value of the first
+failing sub-condition.
+
+```
+require amount is above 50000
+require allergy-list not includes "penicillin"
+```
+
+The condition grammar matches `where` and `choose if` — comparison
+operators, `includes`, `not`, compound `and` / `or`, field access
+via `of`. Mixed `and` / `or` in one clause triggers the amber prompt.
+
+### `assign`
+
+Stores an item-to-recipient mapping. The item becomes the variable
+name; the recipient becomes its value.
+
+```
+assign review-task to "compliance-team"
+assign case-47 to supervisor
+```
+
+`assign` overwrites any existing entry with that name. Combine with
+`when` for reactive delegation: change the trigger, and the handler
+re-assigns the recipient.
+
+### `expect`
+
+Evaluates a condition like `require`, but does not halt on failure.
+A met expectation is silent; a diverged expectation emits one output
+line — `Expectation not met: <condition>. <actual>.` — and execution
+continues with `SUCCESS`.
+
+```
+expect revenue is above 1000000
+expect margin is above 0.1
+```
+
+`require` is enforcement (halt on fail); `expect` is informational
+tracking (report on fail, keep going). Both share the same condition
+grammar.
+
+### Sequencing with `then`
+
+Two operations joined with `then` form a declared sequence — same
+parser shape as `and`, but with stated ordering intent.
+
+```
+add "received" to audit-log then require amount is above 50000
+```
+
+Stepwise commit applies: earlier operations remain even if a later
+one fails.
 
 ## Lists
 
@@ -650,7 +746,7 @@ A literal value can be:
   `"filter"` (the literal word "filter" as data, not the verb). See
   [Quoting](#quoting-v2c) for the full rules.
 
-Vocabulary words (the 40 reserved words) cannot be used **unquoted**
+Vocabulary words (the 44 reserved words) cannot be used **unquoted**
 as values:
 
 ```

--- a/docs/roadmap/v1-v2-boundary.md
+++ b/docs/roadmap/v1-v2-boundary.md
@@ -36,10 +36,10 @@ If a feature is shipped, it has a locked specification, a working implementation
 - **Single-threaded event queue (Phase 2).** Adapters push `(name, value)` updates into a shared FIFO. The interpreter drains one update to completion (write → re-eval → fire-eligible → cascade) before the next dequeue. (v3a §119)
 - **Edge-triggered evaluation (Phase 2).** Handlers fire on false→true transitions of their compound eligibility. Unchanged adapter updates are silently absorbed. Modifications inside an action block are coalesced by name and cascade depth-first. (v3a §113/§114)
 
-### Vocabulary (40 reserved words)
+### Vocabulary (44 reserved words)
 
-- **13 verbs:** `remember`, `show`, `filter`, `keep`, `count`, `gather`, `combine`, `each`, `choose`, `finish`, `add`, `remove`, `weakens`.
-- **17 connectives:** `where`, `and`, `or`, `from`, `with`, `called`, `to`, `how`, `as`, `of`, `if`, `otherwise`, `when`, `unless`, `includes`, `within`, `over`.
+- **16 verbs:** `remember`, `show`, `filter`, `keep`, `count`, `gather`, `combine`, `each`, `choose`, `finish`, `add`, `remove`, `weakens`, `require`, `assign`, `expect`.
+- **18 connectives:** `where`, `and`, `or`, `from`, `with`, `called`, `to`, `how`, `as`, `of`, `if`, `otherwise`, `when`, `unless`, `includes`, `within`, `over`, `then`.
 - **4 single-word operators:** `is`, `above`, `below`, `not`. Plus `equal` as a multi-word component (combines with `to` per inception §22).
 - **3 articles:** `the`, `a`, `an`.
 - **1 delimiter:** `:`.

--- a/src/liminate/vocabulary.py
+++ b/src/liminate/vocabulary.py
@@ -22,6 +22,15 @@ Sources:
 - `within` connective addendum (12 verbs, 16 connectives, 38 reserved
   words total) — used by the session pack's `measure` verb for numeric
   tolerance.
+- Metabolic Era batch 1 (13 verbs, 17 connectives, 40 reserved words
+  total) — `weakens` verb (autonomous linear decay) and `over`
+  connective (decay period).
+- Normative Era batch 2 (14 verbs, 18 connectives, 42 reserved words
+  total) — `require` verb (enforcement) and `then` connective
+  (declared sequencing).
+- Delegated/Epistemic Era batch 3 (16 verbs, 18 connectives, 44
+  reserved words total) — `assign` verb (item-to-recipient mapping)
+  and `expect` verb (non-halting tracked anticipation).
 """
 
 from dataclasses import dataclass
@@ -142,8 +151,8 @@ def reserved_category(word: str) -> str | None:
 
     v4a §137: active pack verbs report as "verb"; active pack nouns
     report as "noun". Pack words are only reserved while the pack that
-    declared them is loaded — the base vocabulary stays permanently at
-    38 words.
+    declared them is loaded — the base vocabulary is the canonical
+    surface (currently 44 reserved words; see module docstring).
     """
     if word in VERBS:
         return "verb"


### PR DESCRIPTION
Living-docs propagation of the Delegated/Epistemic Era batch merged in PR #9.

Files: AGENTS.md, CLAUDE.md, README.md, docs/DEV_README.md, docs/language/syntax.md (count fixes + 7 new verb sub-sections for add/remove/weakens/require/assign/expect plus a sequencing-with-then note), docs/roadmap/v1-v2-boundary.md, src/liminate/vocabulary.py (changelog + reserved_category docstring).

Also includes the liminate-site handoff packet at docs/handoffs/liminate_site_handoff_2026_05_19_assign_expect.md.

972 tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)