### PR TITLE
feat: add `sort` verb and `reverse` modifier — infrastructure era batch 2 (49 → 51 reserved words)

### DIFF
--- a/src/liminate/analyzer.py
+++ b/src/liminate/analyzer.py
@@ -79,6 +79,7 @@ from .parser import (
     RequireNode,
     SequenceNode,
     ShowNode,
+    SortNode,
     WeakensNode,
     WhenNode,
 )
@@ -330,6 +331,8 @@ def _check(
             in_action_block=in_action_block,
             live_value_names=live_value_names,
         )
+    elif isinstance(node, SortNode):
+        _check_sort(node, symtab, live_value_names=live_value_names)
     elif isinstance(node, FinishNode):
         # v3a §112: `finish` is legal only inside a `when` action block
         # (directly, in a `choose` branch, or in a composition called
@@ -502,6 +505,10 @@ def _side_effect_verb(
         # Delegated Era batch 3 — `assign` stores into the symbol
         # table; returns no value.
         return "assign"
+    if isinstance(node, SortNode):
+        # Infrastructure Era batch 2 — `sort` reorders the list in
+        # place; returns no value.
+        return "sort"
     if isinstance(node, (RememberListNode, RememberRecordNode, RememberCompositionNode)):
         return "remember"
     if isinstance(node, RememberValueNode):
@@ -900,6 +907,51 @@ def _check_filter(
     entry = _require_list(name, symtab, verb="filter")
     iterator = _make_iterator(name, entry)
     _check_condition(node.condition, symtab, iterator)
+
+
+def _check_sort(
+    node: SortNode,
+    symtab: dict[str, SymbolEntry],
+    *,
+    live_value_names: set[str] | None = None,
+) -> None:
+    """Infrastructure Era batch 2 — validate the `sort` verb.
+
+    1. Sort is destructive (in-place reorder), so adapter-owned live
+       values cannot be sorted.
+    2. Target must exist and be a list.
+    3. If the list is a known list_of_records and not empty, the field
+       must exist on every record's schema. Empty lists and lists with
+       no record schema (e.g. flat scalar lists) defer the field check
+       to runtime — sorting a non-record list is a runtime error so the
+       message can name the offending item.
+    """
+    name = node.target.name
+    if live_value_names and name in live_value_names:
+        raise _SemanticError(
+            f"'{name}' is a live value provided by the domain pack. "
+            f"'sort' is destructive and can't modify it."
+        )
+    if name not in symtab:
+        raise _SemanticError(
+            f"I can't find '{name}'. "
+            f"You might need to 'remember' it first."
+        )
+    entry = symtab[name]
+    if entry.type not in ("list_of_numbers", "list_of_strings", "list_of_records"):
+        raise _SemanticError(
+            f"I can only sort a list. '{name}' is {_singular(entry.type)}."
+        )
+    if entry.type == "list_of_records" and entry.value:
+        iterator = _make_iterator(name, entry)
+        if iterator.record_schemas is not None:
+            in_all = all(node.field in s for s in iterator.record_schemas)
+            if not in_all:
+                raise _SemanticError(
+                    _schema_mismatch_message(
+                        entry, iterator.record_schemas, node.field,
+                    )
+                )
 
 
 def _check_keep(node: KeepNode, symtab: dict[str, SymbolEntry]) -> None:

--- a/src/liminate/interpreter.py
+++ b/src/liminate/interpreter.py
@@ -93,6 +93,7 @@ from .parser import (
     RequireNode,
     SequenceNode,
     ShowNode,
+    SortNode,
     WeakensNode,
     WhenNode,
 )
@@ -564,6 +565,8 @@ def _exec_op(
         return _exec_expect(node, symtab, current_item)
     if isinstance(node, AssignNode):
         return _exec_assign(node, symtab, current_item)
+    if isinstance(node, SortNode):
+        return _exec_sort(node, symtab)
     if isinstance(node, FinishNode):
         # v3a §112 — immediate and total. The exception unwinds out of
         # any surrounding choose/sequence/composition straight to the
@@ -1016,6 +1019,44 @@ def _exec_filter(node: FilterNode, symtab: dict[str, SymbolEntry]) -> list[str]:
     entry = symtab[node.target.name]
     kept = [item for item in entry.value if _eval_condition(node.condition, item, symtab)]
     entry.value[:] = kept  # in-place per §24 line 478
+    return []
+
+
+def _exec_sort(node: SortNode, symtab: dict[str, SymbolEntry]) -> list[str]:
+    """Infrastructure Era batch 2 — in-place sort by a record field.
+
+    Silent like `filter`. Empty lists are a no-op. Non-record items
+    surface as runtime errors so the user gets a clear message instead
+    of a Python exception. Mixed-type field values (some numeric, some
+    text) raise TypeError under Python's stable sort — caught and
+    re-raised as a runtime error.
+    """
+    entry = symtab[node.target.name]
+    the_list = entry.value
+    if not the_list:
+        return []
+    for i, item in enumerate(the_list):
+        if not isinstance(item, dict):
+            raise _RuntimeError(
+                f"I can only sort a list of records by a field. "
+                f"Item {i + 1} in '{node.target.name}' is "
+                f"{_format_scalar(item)}."
+            )
+        if node.field not in item:
+            raise _RuntimeError(
+                f"Record {i + 1} in '{node.target.name}' doesn't "
+                f"have a field called '{node.field}'."
+            )
+    try:
+        the_list.sort(
+            key=lambda r: r[node.field],
+            reverse=node.descending,
+        )
+    except TypeError:
+        raise _RuntimeError(
+            f"I can't sort '{node.target.name}' by '{node.field}' — "
+            f"the values are a mix of types that can't be compared."
+        )
     return []
 
 

--- a/src/liminate/parser.py
+++ b/src/liminate/parser.py
@@ -389,6 +389,19 @@ class ArithmeticNode(ASTNode):
 
 
 @dataclass
+class SortNode(ASTNode):
+    """Infrastructure Era batch 2 — sort a list in place by a field.
+
+    `target` is the list to sort. `field` is the field name to sort by.
+    `descending` is True when the `reverse` modifier is present
+    (optionally preceded by the word `in`).
+    """
+    target: NameRef
+    field: str
+    descending: bool = False
+
+
+@dataclass
 class ExpectNode(ASTNode):
     """Epistemic Era batch 3 — tracked anticipation verb.
 
@@ -779,6 +792,8 @@ def _parse_verb_statement(stream: TokenStream, comp: set[str]) -> ASTNode:
         return _parse_assign(stream)
     if verb.value == "expect":
         return _parse_expect(stream)
+    if verb.value == "sort":
+        return _parse_sort(stream)
     if verb.value == "finish":
         # v3a §112 — slot-less verb. Phase 1 semantic check (in the
         # analyzer) rejects calls outside an action-block context; here
@@ -1476,6 +1491,88 @@ def _parse_expect(stream: TokenStream) -> ExpectNode:
     finally:
         stream.pop_clause()
     return ExpectNode(condition=condition)
+
+
+# ---------------------------------------------------------------------------
+# sort (Infrastructure Era batch 2)
+# ---------------------------------------------------------------------------
+
+
+def _parse_sort(stream: TokenStream) -> SortNode:
+    """`sort [article]? <target> by <field> [in]? [reverse]?`.
+
+    The optional `in` before `reverse` is NOT a reserved word — the
+    parser consumes it as an UNKNOWN token only when `reverse` follows.
+    This keeps the natural English phrasing (`sort by total in reverse`)
+    while leaving `in` available as a user variable name elsewhere.
+    """
+    _consume_optional_article(stream)
+    if stream.at_end():
+        raise _ParseError(
+            "'sort' needs a target list and a field — try: "
+            "sort <list> by <field>."
+        )
+    target = _consume_target(stream, verb="sort")
+
+    by_tok = stream.consume()
+    if not (
+        by_tok
+        and by_tok.type is TokenType.CONNECTIVE
+        and by_tok.value == "by"
+    ):
+        raise _ParseError(
+            "'sort' needs a field to sort by — try: "
+            "sort <list> by <field>."
+        )
+
+    field_tok = stream.consume()
+    if field_tok is None:
+        raise _ParseError("I expected a field name after 'by'.")
+    if field_tok.type is TokenType.QUOTED_STRING:
+        raise _ParseError(
+            f"Field names can't have spaces. Try a hyphenated name "
+            f"like '{_hyphenate(field_tok.value)}' instead."
+        )
+    if field_tok.type is not TokenType.UNKNOWN:
+        cat = reserved_category(field_tok.value)
+        if cat:
+            raise _ParseError(
+                f"The word '{field_tok.value}' is reserved in Liminate "
+                f"— it's used as a {cat}. Please use a field name "
+                f"from your records."
+            )
+        raise _ParseError(
+            f"I expected a field name after 'by', not '{field_tok.value}'."
+        )
+    field_name = field_tok.value
+
+    descending = False
+    peek = stream.peek()
+    if (
+        peek
+        and peek.type is TokenType.UNKNOWN
+        and peek.value == "in"
+    ):
+        # Only consume the `in` if `reverse` follows it. A lone trailing
+        # `in` is left in the stream for the outer parser to surface.
+        peek2 = stream.peek(1)
+        if (
+            peek2
+            and peek2.type is TokenType.OPERATOR
+            and peek2.value == "reverse"
+        ):
+            stream.consume()  # in
+            stream.consume()  # reverse
+            descending = True
+    elif (
+        peek
+        and peek.type is TokenType.OPERATOR
+        and peek.value == "reverse"
+    ):
+        stream.consume()  # reverse
+        descending = True
+
+    return SortNode(target=target, field=field_name, descending=descending)
 
 
 # ---------------------------------------------------------------------------

--- a/src/liminate/renderer.py
+++ b/src/liminate/renderer.py
@@ -55,6 +55,7 @@ from .parser import (
     RequireNode,
     SequenceNode,
     ShowNode,
+    SortNode,
     WeakensNode,
     WhenNode,
 )
@@ -202,6 +203,14 @@ def render(node: ASTNode) -> str:
     if isinstance(node, AssignNode):
         # Delegated Era batch 3 — `assign <item> to <recipient>`.
         return f"assign {node.item.name} to {render(node.recipient)}"
+    if isinstance(node, SortNode):
+        # Infrastructure Era batch 2 — canonical form keeps the natural
+        # `in reverse` for descending; ascending is the default and
+        # omits the modifier.
+        base = f"sort the {node.target.name} by {node.field}"
+        if node.descending:
+            return f"{base} in reverse"
+        return base
 
     if isinstance(node, PackVerbNode):
         # v4a §137 + v2: pack verbs render as `<word> [<conn>] <value>...`

--- a/src/liminate/vocabulary.py
+++ b/src/liminate/vocabulary.py
@@ -35,6 +35,9 @@ Sources:
   total) — `by` connective, `plus`/`minus` operators,
   `multiplied by`/`divided by` multi-word operators. Arithmetic
   expressions with PEMDAS precedence.
+- Infrastructure Era batch 2 (17 verbs, 19 connectives, 51 reserved
+  words total) — `sort` verb (in-place list reordering by field) and
+  `reverse` operator (descending sort modifier).
 """
 
 from dataclasses import dataclass
@@ -82,6 +85,9 @@ VERBS: frozenset[str] = frozenset({
     # Epistemic Era batch 3: `expect <condition>` evaluates a condition
     # and emits a divergence output line on failure; never halts.
     "expect",
+    # Infrastructure Era batch 2: `sort` reorders a list in place by a
+    # field value. Default ascending; `reverse` modifier for descending.
+    "sort",
 })
 
 # v1 / v2a / v2d / v3a connectives. v2a §68 added `of`. v2d §99 added
@@ -115,6 +121,10 @@ OPERATORS: frozenset[str] = frozenset({
     # (combined by the lexer; `multiplied` and `divided` live in
     # MULTI_WORD_RESERVED).
     "plus", "minus",
+    # Infrastructure Era batch 2: `reverse` modifies `sort` direction
+    # from ascending (default) to descending. Lives in OPERATORS so the
+    # name-position check rejects it as a variable name.
+    "reverse",
 })
 
 # v1 articles. `an` added in v1c §47 (previously the table listed `the`, `a`).
@@ -145,7 +155,7 @@ MULTI_WORD_RESERVED: frozenset[str] = frozenset({
     "multiplied", "divided",
 })
 
-# All 49 reserved words. 16 verbs, 19 connectives, 6 operators, 3
+# All 51 reserved words. 17 verbs, 19 connectives, 7 operators, 3
 # articles, 2 V2-reserved, 3 multi-word reserved. v3a §124 was 34
 # (+1 for `finish`). Liminate `add` verb addendum v1 §9: +1 for `add`
 # (appends an item to a list). `includes` connective + `remove` verb
@@ -158,7 +168,9 @@ MULTI_WORD_RESERVED: frozenset[str] = frozenset({
 # batch 3: +2 — `assign` (item-to-recipient mapping) and `expect`
 # (tracked anticipation, non-halting divergence). Infrastructure Era:
 # +5 — `by` connective, `plus`/`minus` operators, `multiplied` and
-# `divided` multi-word lookahead triggers.
+# `divided` multi-word lookahead triggers. Infrastructure Era batch 2:
+# +2 — `sort` verb (in-place list reordering by a field) and `reverse`
+# operator (descending sort modifier).
 ALL_RESERVED: frozenset[str] = (
     VERBS | CONNECTIVES | OPERATORS | ARTICLES | V2_RESERVED | MULTI_WORD_RESERVED
 )
@@ -174,7 +186,7 @@ def reserved_category(word: str) -> str | None:
     v4a §137: active pack verbs report as "verb"; active pack nouns
     report as "noun". Pack words are only reserved while the pack that
     declared them is loaded — the base vocabulary is the canonical
-    surface (currently 49 reserved words; see module docstring).
+    surface (currently 51 reserved words; see module docstring).
     """
     if word in VERBS:
         return "verb"
@@ -368,6 +380,8 @@ VERB_SIGNATURES: dict[str, list[str]] = {
     # Epistemic Era batch 3: `expect <condition>`. Same condition
     # grammar as `require` / `choose if` / `where`.
     "expect":   ["condition"],
+    # Infrastructure Era batch 2: `sort <target> by <field> [reverse]`.
+    "sort":     ["target", "field"],
 }
 
 

--- a/tests/test_sort.py
+++ b/tests/test_sort.py
@@ -1,0 +1,265 @@
+"""Integration tests for the Infrastructure Era batch 2 `sort` verb and
+`reverse` modifier — sentences 154–164.
+
+Each test runs the program through the full pipeline via Session.run_line.
+"""
+
+from __future__ import annotations
+
+from liminate.cli import Session
+from liminate.result import ResultStatus
+
+
+def run_lines(lines):
+    session = Session()
+    results = [session.run_line(line) for line in lines]
+    return session, results
+
+
+# ---------------------------------------------------------------------------
+# Sentence 154 — ascending sort by numeric field
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_154_ascending_sort_by_number():
+    session, results = run_lines([
+        "remember an order called o1 with total as 75",
+        "remember an order called o2 with total as 30",
+        "remember an order called o3 with total as 120",
+        "remember a list called orders with o1 and o2 and o3",
+        "sort the orders by total",
+        "each the orders show total",
+    ])
+    for r in results:
+        assert r.status is ResultStatus.SUCCESS, r.message
+    assert results[-1].output == ["30", "75", "120"]
+
+
+# ---------------------------------------------------------------------------
+# Sentence 155 — descending sort with `in reverse`
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_155_descending_with_in_reverse():
+    session, results = run_lines([
+        "remember an order called o1 with total as 75",
+        "remember an order called o2 with total as 30",
+        "remember an order called o3 with total as 120",
+        "remember a list called orders with o1 and o2 and o3",
+        "sort the orders by total in reverse",
+        "each the orders show total",
+    ])
+    for r in results:
+        assert r.status is ResultStatus.SUCCESS, r.message
+    assert results[-1].output == ["120", "75", "30"]
+
+
+# ---------------------------------------------------------------------------
+# Sentence 156 — descending sort with bare `reverse`
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_156_descending_with_bare_reverse():
+    session, results = run_lines([
+        "remember an order called o1 with total as 75",
+        "remember an order called o2 with total as 30",
+        "remember a list called orders with o1 and o2",
+        "sort orders by total reverse",
+        "each the orders show total",
+    ])
+    for r in results:
+        assert r.status is ResultStatus.SUCCESS, r.message
+    assert results[-1].output == ["75", "30"]
+
+
+# ---------------------------------------------------------------------------
+# Sentence 157 — sort by string field (alphabetical)
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_157_sort_by_string_field():
+    session, results = run_lines([
+        "remember a person called p1 with name as charlie",
+        "remember a person called p2 with name as alice",
+        "remember a person called p3 with name as bob",
+        "remember a list called people with p1 and p2 and p3",
+        "sort the people by name",
+        "each the people show name",
+    ])
+    for r in results:
+        assert r.status is ResultStatus.SUCCESS, r.message
+    assert results[-1].output == ["alice", "bob", "charlie"]
+
+
+# ---------------------------------------------------------------------------
+# Sentence 158 — sort preserves other fields
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_158_sort_preserves_other_fields():
+    session, results = run_lines([
+        "remember an order called o1 with total as 75 and status as active",
+        "remember an order called o2 with total as 30 and status as pending",
+        "remember a list called orders with o1 and o2",
+        "sort the orders by total",
+        "each the orders show total and status",
+    ])
+    for r in results:
+        assert r.status is ResultStatus.SUCCESS, r.message
+    assert results[-1].output == [
+        "total: 30, status: pending",
+        "total: 75, status: active",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Sentence 159 — sort empty list (no error, no output)
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_159_sort_empty_list_is_noop():
+    session, results = run_lines([
+        "remember an order called o1 with total as 999",
+        "remember a list called orders with o1",
+        "filter the orders where total is above 10000",
+        "sort the orders by total",
+        "count the orders",
+    ])
+    for r in results:
+        assert r.status is ResultStatus.SUCCESS, r.message
+    assert results[-1].output == ["0"]
+
+
+# ---------------------------------------------------------------------------
+# Sentence 160 — sort then filter (operations compose)
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_160_sort_then_filter():
+    session, results = run_lines([
+        "remember an order called o1 with total as 75",
+        "remember an order called o2 with total as 30",
+        "remember an order called o3 with total as 120",
+        "remember a list called orders with o1 and o2 and o3",
+        "sort the orders by total",
+        "filter the orders where total is above 50",
+        "each the orders show total",
+    ])
+    for r in results:
+        assert r.status is ResultStatus.SUCCESS, r.message
+    assert results[-1].output == ["75", "120"]
+
+
+# ---------------------------------------------------------------------------
+# Sentence 161 — sort on non-list target (semantic error)
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_161_sort_non_list_errors():
+    session, results = run_lines([
+        "remember a value called total with 100",
+        "sort total by amount",
+    ])
+    assert results[0].status is ResultStatus.SUCCESS, results[0].message
+    assert results[1].status is ResultStatus.ERROR_SEMANTIC
+    assert "I can only sort a list" in (results[1].message or "")
+    assert "total" in (results[1].message or "")
+
+
+# ---------------------------------------------------------------------------
+# Sentence 162 — sort by missing field (semantic error)
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_162_sort_by_missing_field_errors():
+    session, results = run_lines([
+        "remember an order called o1 with total as 75",
+        "remember a list called orders with o1",
+        "sort the orders by missing-field",
+    ])
+    for r in results[:2]:
+        assert r.status is ResultStatus.SUCCESS, r.message
+    assert results[-1].status is ResultStatus.ERROR_SEMANTIC
+    assert "missing-field" in (results[-1].message or "")
+
+
+# ---------------------------------------------------------------------------
+# Sentence 163 — sort inside an `and`-sequenced operation pair
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_163_sort_inside_operation_sequence():
+    session, results = run_lines([
+        "remember an order called o1 with total as 75",
+        "remember an order called o2 with total as 30",
+        "remember a list called orders with o1 and o2",
+        "sort the orders by total and each the orders show total",
+    ])
+    for r in results:
+        assert r.status is ResultStatus.SUCCESS, r.message
+    assert results[-1].output == ["30", "75"]
+
+
+# ---------------------------------------------------------------------------
+# Sentence 164 — sort with `then` sequencing
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_164_sort_with_then_sequencing():
+    session, results = run_lines([
+        "remember an order called o1 with total as 75",
+        "remember an order called o2 with total as 30",
+        "remember a list called orders with o1 and o2",
+        "sort the orders by total then each the orders show total",
+    ])
+    for r in results:
+        assert r.status is ResultStatus.SUCCESS, r.message
+    assert results[-1].output == ["30", "75"]
+
+
+# ---------------------------------------------------------------------------
+# `reverse` is a reserved word — rejected as a variable name
+# ---------------------------------------------------------------------------
+
+
+def test_reverse_is_reserved_as_a_name():
+    session, results = run_lines([
+        "remember a value called reverse with 5",
+    ])
+    assert results[0].status is ResultStatus.ERROR_PARSE
+    assert "reverse" in (results[0].message or "")
+    assert "operator" in (results[0].message or "")
+
+
+# ---------------------------------------------------------------------------
+# `in` is NOT reserved — usable as a variable name
+# ---------------------------------------------------------------------------
+
+
+def test_in_is_not_reserved():
+    from liminate.vocabulary import (
+        ALL_RESERVED, ARTICLES, CONNECTIVES, MULTI_WORD_RESERVED, OPERATORS,
+        V2_RESERVED, VERBS,
+    )
+    assert "in" not in ALL_RESERVED
+    for s in (VERBS, CONNECTIVES, OPERATORS, ARTICLES,
+              V2_RESERVED, MULTI_WORD_RESERVED):
+        assert "in" not in s
+
+
+# ---------------------------------------------------------------------------
+# Canonical rendering round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_sort_renders_canonically():
+    from liminate.lexer import tokenize
+    from liminate.parser import parse
+    from liminate.renderer import render
+
+    for src in (
+        "sort the orders by total",
+        "sort the orders by total in reverse",
+    ):
+        ast = parse(tokenize(src))
+        assert parse(tokenize(render(ast))) == ast

--- a/tests/test_vocabulary.py
+++ b/tests/test_vocabulary.py
@@ -17,14 +17,14 @@ from liminate.vocabulary import (
 
 
 def test_verb_count():
-    # 16 verbs: 14 + 2 (`assign` — Delegated Era batch 3 delegation;
-    # `expect` — Epistemic Era batch 3 tracked anticipation).
-    assert len(VERBS) == 16
+    # 17 verbs: 16 + 1 (`sort` — Infrastructure Era batch 2 in-place
+    # list reordering by field).
+    assert len(VERBS) == 17
     assert VERBS == {
         "remember", "show", "filter", "keep", "count",
         "gather", "combine", "each", "choose", "finish",
         "add", "remove", "weakens", "require",
-        "assign", "expect",
+        "assign", "expect", "sort",
     }
 
 
@@ -43,11 +43,14 @@ def test_connective_count():
 
 
 def test_operator_count():
-    # 6 single-word operators (was 4); Infrastructure Era added `plus`
-    # and `minus`. `equal to` / `multiplied by` / `divided by` are
-    # multi-word lexer tokens combined from MULTI_WORD_RESERVED triggers.
-    assert len(OPERATORS) == 6
-    assert OPERATORS == {"is", "above", "below", "not", "plus", "minus"}
+    # 7 single-word operators (was 6); Infrastructure Era batch 2 added
+    # `reverse` as the descending-sort modifier. `equal to` /
+    # `multiplied by` / `divided by` are multi-word lexer tokens
+    # combined from MULTI_WORD_RESERVED triggers.
+    assert len(OPERATORS) == 7
+    assert OPERATORS == {
+        "is", "above", "below", "not", "plus", "minus", "reverse",
+    }
 
 
 def test_article_count():
@@ -74,11 +77,11 @@ def test_multi_word_reserved():
     assert MULTI_WORD_RESERVED == {"equal", "multiplied", "divided"}
 
 
-def test_total_reserved_count_is_49():
-    # 49 reserved words total (Infrastructure Era). 16 verbs +
-    # 19 connectives + 6 operators + 3 multi-word + 3 articles +
-    # 2 v2-deferred verbs = 49.
-    assert len(ALL_RESERVED) == 49
+def test_total_reserved_count_is_51():
+    # 51 reserved words total (Infrastructure Era batch 2). 17 verbs +
+    # 19 connectives + 7 operators + 3 multi-word + 3 articles +
+    # 2 v2-deferred verbs = 51.
+    assert len(ALL_RESERVED) == 51
 
 
 def test_reserved_sets_are_disjoint():
@@ -142,6 +145,8 @@ def test_verb_signature_slot_shapes():
     assert VERB_SIGNATURES["assign"] == ["item", "recipient"]
     # Epistemic Era batch 3: `expect <condition>`.
     assert VERB_SIGNATURES["expect"] == ["condition"]
+    # Infrastructure Era batch 2: `sort <target> by <field>`.
+    assert VERB_SIGNATURES["sort"] == ["target", "field"]
 
 
 def test_add_is_classified_as_verb():


### PR DESCRIPTION
## Summary

Adds `sort` (17th verb) and `reverse` (descending modifier) to the base vocabulary. Programs can now express `sort the orders by total` (ascending) and `sort the orders by total in reverse` (descending). `in` is NOT reserved — the parser only consumes it when `reverse` follows, so it remains free as a user variable name elsewhere.

- **Vocabulary:** 49 → 51 base reserved words. 17 verbs (was 16), 19 connectives (unchanged), 7 operators (was 6).
- **Parser:** new `SortNode`; `_parse_sort` handles target, `by <field>`, and the optional `[in]? reverse?` modifier with peek-ahead so a dangling `in` is never silently swallowed.
- **Analyzer:** `_check_sort` validates the target as a list and, for known list_of_records, that the field exists on every record's schema. Live-value targets rejected (sort is destructive). `SortNode` added to `_side_effect_verb`.
- **Interpreter:** `_exec_sort` uses Python's stable `list.sort()` in place with `key=lambda r: r[field]` and `reverse=node.descending`. Empty list is a no-op. Non-record items and mixed-type field values surface as clean runtime errors.
- **Renderer:** canonical form `sort the <list> by <field>` (+ `in reverse` for descending). Round-trip verified.

## Phases completed
Vocabulary · Parser · Analyzer · Interpreter · Renderer · Tests.

## Files
**Modified:** `src/liminate/{vocabulary,parser,analyzer,interpreter,renderer}.py`, `tests/test_vocabulary.py`.
**Created:** `tests/test_sort.py`.

## Invariants satisfied (§7)
1. `sort` in VERBS and VERB_SIGNATURES ✓
2. `reverse` in OPERATORS ✓
3. `by` remains in CONNECTIVES (from PR #11) ✓
4. `sort` is in-place — same list reference is reordered ✓
5. `in` NOT added to any vocabulary set (verified by `test_in_is_not_reserved`) ✓
6. `_parse_sort` consumes `in` only when `reverse` follows (peek-ahead) ✓

## Tests
1017 pass (was 1003 → +14):
- 11 sentence-style integration tests (154–164) covering ascending, descending with `in reverse`, bare `reverse`, alphabetical string sort, field preservation, empty-list no-op, sort+filter composition, `and`/`then` sequencing, non-list error, missing-field error.
- `reverse` reserved as a name (rejected with operator category).
- `in` NOT reserved (verified absent from every frozenset).
- Canonical round-trip on both ascending and descending forms.

## Sort behavior confirmed
- Ascending `sort the orders by total` over totals 75/30/120 → `[30, 75, 120]` ✓
- Descending `sort the orders by total in reverse` → `[120, 75, 30]` ✓
- Field preservation: sorted records retain all fields (`total: 30, status: pending` etc.) ✓
- Bare `reverse` (no `in`) also produces descending ✓

## Test plan
- [x] `pytest tests/` — 1017 pass
- [x] Ascending / descending behavior verified on records with totals 75/30/120
- [x] Field preservation across sort
- [x] `in` remains usable as a non-reserved word
- [x] Canonical round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)