### PR TITLE
feat: promote `compare` from V2-reserved to base verb (17 → 18 verbs)

### DIFF
--- a/src/liminate/analyzer.py
+++ b/src/liminate/analyzer.py
@@ -55,6 +55,7 @@ from .parser import (
     ChooseBranch,
     ChooseNode,
     CombineNode,
+    CompareNode,
     CompositionCallNode,
     CompoundConditionNode,
     ConditionNode,
@@ -333,6 +334,8 @@ def _check(
         )
     elif isinstance(node, SortNode):
         _check_sort(node, symtab, live_value_names=live_value_names)
+    elif isinstance(node, CompareNode):
+        _check_compare(node, symtab)
     elif isinstance(node, FinishNode):
         # v3a §112: `finish` is legal only inside a `when` action block
         # (directly, in a `choose` branch, or in a composition called
@@ -509,6 +512,10 @@ def _side_effect_verb(
         # Infrastructure Era batch 2 — `sort` reorders the list in
         # place; returns no value.
         return "sort"
+    if isinstance(node, CompareNode):
+        # V2 promotion — `compare` stores the `comparison` record as a
+        # side effect; the verb phrase itself produces no value.
+        return "compare"
     if isinstance(node, (RememberListNode, RememberRecordNode, RememberCompositionNode)):
         return "remember"
     if isinstance(node, RememberValueNode):
@@ -952,6 +959,22 @@ def _check_sort(
                         entry, iterator.record_schemas, node.field,
                     )
                 )
+
+
+def _check_compare(
+    node: CompareNode,
+    symtab: dict[str, SymbolEntry],
+) -> None:
+    """V2 promotion — validate the `compare` verb. Both operands must
+    exist in the symbol table. No cross-operand type constraint: the
+    interpreter handles type mismatches gracefully (`type_mismatch`
+    status), so the analyzer only checks existence."""
+    for ref in (node.left, node.right):
+        if ref.name not in symtab:
+            raise _SemanticError(
+                f"I can't find '{ref.name}'. "
+                f"You might need to 'remember' it first."
+            )
 
 
 def _check_keep(node: KeepNode, symtab: dict[str, SymbolEntry]) -> None:

--- a/src/liminate/interpreter.py
+++ b/src/liminate/interpreter.py
@@ -69,6 +69,7 @@ from .parser import (
     ChooseBranch,
     ChooseNode,
     CombineNode,
+    CompareNode,
     CompositionCallNode,
     CompoundConditionNode,
     ConditionNode,
@@ -567,6 +568,8 @@ def _exec_op(
         return _exec_assign(node, symtab, current_item)
     if isinstance(node, SortNode):
         return _exec_sort(node, symtab)
+    if isinstance(node, CompareNode):
+        return _exec_compare(node, symtab, current_item)
     if isinstance(node, FinishNode):
         # v3a §112 — immediate and total. The exception unwinds out of
         # any surrounding choose/sequence/composition straight to the
@@ -997,7 +1000,14 @@ def _exec_show(
     # has the field) already ran in the analyzer.
     if node.record_name is not None:
         record = symtab[node.record_name].value
-        return [_format_scalar(record[name])]
+        # A field may itself be a list (e.g. the `divergences` field of a
+        # `comparison` record). Use the list display format rather than
+        # Python's repr so it reads as `status, total`, not `['status',
+        # 'total']`.
+        field_value = record[name]
+        if isinstance(field_value, list):
+            return _display_lines(field_value)
+        return [_format_scalar(field_value)]
     # v2a §69 (D1): multi-field display inside `each ... show`.
     if node.extra_fields and isinstance(current_item, dict):
         fields = [name, *node.extra_fields]
@@ -1057,6 +1067,67 @@ def _exec_sort(node: SortNode, symtab: dict[str, SymbolEntry]) -> list[str]:
             f"I can't sort '{node.target.name}' by '{node.field}' — "
             f"the values are a mix of types that can't be compared."
         )
+    return []
+
+
+def _exec_compare(
+    node: CompareNode,
+    symtab: dict[str, SymbolEntry],
+    current_item: Any,
+) -> list[str]:
+    """V2 promotion — compare two domain values and store a structured
+    `comparison` record. Comparison mode is inferred from operand types:
+
+    - record vs record  → structural; divergences = sorted diverging keys
+    - list vs list       → structural; divergences = diverging indices
+      (length_mismatch when lengths differ)
+    - record/list vs the other shape, or a container vs a scalar
+                         → type_mismatch
+    - scalar vs scalar   → equality; divergences = []
+
+    `_evaluate_expression` resolves DecayingValue operands to their
+    current decayed value, so decay-wrapped numbers compare on their
+    effective value. Silent — no output; result stored only.
+    """
+    left_val = _evaluate_expression(node.left, symtab, current_item)
+    right_val = _evaluate_expression(node.right, symtab, current_item)
+
+    left_is_dict = isinstance(left_val, dict)
+    right_is_dict = isinstance(right_val, dict)
+    left_is_list = isinstance(left_val, list)
+    right_is_list = isinstance(right_val, list)
+
+    divergences: list[Any]
+    if left_is_dict and right_is_dict:
+        all_keys = set(left_val) | set(right_val)
+        diverging = [
+            k for k in sorted(all_keys)
+            if k not in left_val or k not in right_val
+            or left_val[k] != right_val[k]
+        ]
+        status = "match" if not diverging else "mismatch"
+        divergences = diverging
+    elif left_is_list and right_is_list:
+        if len(left_val) != len(right_val):
+            status = "length_mismatch"
+            divergences = []
+        else:
+            diverging_idx = [
+                i for i, (l, r) in enumerate(zip(left_val, right_val))
+                if l != r
+            ]
+            status = "match" if not diverging_idx else "mismatch"
+            divergences = diverging_idx
+    elif left_is_dict != right_is_dict or left_is_list != right_is_list:
+        # One operand is a record/list and the other is a different
+        # shape (or a scalar).
+        status = "type_mismatch"
+        divergences = []
+    else:
+        status = "match" if left_val == right_val else "mismatch"
+        divergences = []
+
+    _store(symtab, "comparison", {"status": status, "divergences": divergences})
     return []
 
 

--- a/src/liminate/parser.py
+++ b/src/liminate/parser.py
@@ -402,6 +402,19 @@ class SortNode(ASTNode):
 
 
 @dataclass
+class CompareNode(ASTNode):
+    """V2 promotion — structured comparison of two domain values.
+
+    `left` and `right` are NameRefs to values in the symbol table. The
+    interpreter infers comparison mode from operand types and stores a
+    record named `comparison` with fields `status` (string) and
+    `divergences` (list) in the symbol table.
+    """
+    left: NameRef
+    right: NameRef
+
+
+@dataclass
 class ExpectNode(ASTNode):
     """Epistemic Era batch 3 — tracked anticipation verb.
 
@@ -794,6 +807,8 @@ def _parse_verb_statement(stream: TokenStream, comp: set[str]) -> ASTNode:
         return _parse_expect(stream)
     if verb.value == "sort":
         return _parse_sort(stream)
+    if verb.value == "compare":
+        return _parse_compare(stream)
     if verb.value == "finish":
         # v3a §112 — slot-less verb. Phase 1 semantic check (in the
         # analyzer) rejects calls outside an action-block context; here
@@ -1573,6 +1588,38 @@ def _parse_sort(stream: TokenStream) -> SortNode:
         descending = True
 
     return SortNode(target=target, field=field_name, descending=descending)
+
+
+# ---------------------------------------------------------------------------
+# compare (V2 promotion)
+# ---------------------------------------------------------------------------
+
+
+def _parse_compare(stream: TokenStream) -> CompareNode:
+    """`compare [article]? <left> to [article]? <right>`."""
+    _consume_optional_article(stream)
+    if stream.at_end():
+        raise _ParseError(
+            "'compare' needs two values — try: "
+            "compare <name> to <name>."
+        )
+    left = _consume_target(stream, verb="compare")
+
+    to_tok = stream.consume()
+    if not (
+        to_tok
+        and to_tok.type is TokenType.CONNECTIVE
+        and to_tok.value == "to"
+    ):
+        raise _ParseError(
+            "'compare' needs a second value — try: "
+            "compare <name> to <name>."
+        )
+
+    _consume_optional_article(stream)
+    right = _consume_target(stream, verb="compare")
+
+    return CompareNode(left=left, right=right)
 
 
 # ---------------------------------------------------------------------------

--- a/src/liminate/renderer.py
+++ b/src/liminate/renderer.py
@@ -31,6 +31,7 @@ from .parser import (
     ChooseBranch,
     ChooseNode,
     CombineNode,
+    CompareNode,
     CompositionCallNode,
     CompoundConditionNode,
     ConditionNode,
@@ -211,6 +212,9 @@ def render(node: ASTNode) -> str:
         if node.descending:
             return f"{base} in reverse"
         return base
+    if isinstance(node, CompareNode):
+        # V2 promotion — `compare <left> to <right>`.
+        return f"compare {render(node.left)} to {render(node.right)}"
 
     if isinstance(node, PackVerbNode):
         # v4a §137 + v2: pack verbs render as `<word> [<conn>] <value>...`

--- a/src/liminate/vocabulary.py
+++ b/src/liminate/vocabulary.py
@@ -38,6 +38,9 @@ Sources:
 - Infrastructure Era batch 2 (17 verbs, 19 connectives, 51 reserved
   words total) — `sort` verb (in-place list reordering by field) and
   `reverse` operator (descending sort modifier).
+- V2 promotion: `compare` (18 verbs, 51 reserved words total) —
+  structured comparison of two domain values, producing a record
+  named `comparison` with `status` and `divergences` fields.
 """
 
 from dataclasses import dataclass
@@ -88,6 +91,10 @@ VERBS: frozenset[str] = frozenset({
     # Infrastructure Era batch 2: `sort` reorders a list in place by a
     # field value. Default ascending; `reverse` modifier for descending.
     "sort",
+    # V2 promotion: `compare <left> to <right>` produces a structured
+    # result record named `comparison` with `status` and `divergences`
+    # fields. Comparison mode inferred from operand types.
+    "compare",
 })
 
 # v1 / v2a / v2d / v3a connectives. v2a §68 added `of`. v2d §99 added
@@ -138,10 +145,11 @@ DELIMITERS: frozenset[str] = frozenset({":"})
 # v2 deferred words — designed but not executable in v1. Reserved so
 # user programs that use them as names will not silently break when v2
 # ships (v1a §29). v2d §99 promoted `choose` to an active verb. v3a §108
-# promoted `when` and `unless` to active connectives. `transform` and
-# `compare` continue to be deferred per v2d §103 / v3a §124.
+# promoted `when` and `unless` to active connectives. The V2 promotion
+# build moved `compare` to an active verb (structured comparison with a
+# `comparison` result record); `transform` continues to be deferred.
 V2_RESERVED: frozenset[str] = frozenset({
-    "transform", "compare",
+    "transform",
 })
 
 # `equal` is the multi-word lookahead trigger for `equal to`. Reserved
@@ -155,8 +163,8 @@ MULTI_WORD_RESERVED: frozenset[str] = frozenset({
     "multiplied", "divided",
 })
 
-# All 51 reserved words. 17 verbs, 19 connectives, 7 operators, 3
-# articles, 2 V2-reserved, 3 multi-word reserved. v3a §124 was 34
+# All 51 reserved words. 18 verbs, 19 connectives, 7 operators, 3
+# articles, 1 V2-reserved, 3 multi-word reserved. v3a §124 was 34
 # (+1 for `finish`). Liminate `add` verb addendum v1 §9: +1 for `add`
 # (appends an item to a list). `includes` connective + `remove` verb
 # addendum: +2 (list membership test in conditions, retract item from a
@@ -170,7 +178,9 @@ MULTI_WORD_RESERVED: frozenset[str] = frozenset({
 # +5 — `by` connective, `plus`/`minus` operators, `multiplied` and
 # `divided` multi-word lookahead triggers. Infrastructure Era batch 2:
 # +2 — `sort` verb (in-place list reordering by a field) and `reverse`
-# operator (descending sort modifier).
+# operator (descending sort modifier). V2 promotion: +0 net — `compare`
+# moved from V2_RESERVED to VERBS, so the verb count rose to 18 and the
+# V2-reserved count fell to 1; the total stays 51.
 ALL_RESERVED: frozenset[str] = (
     VERBS | CONNECTIVES | OPERATORS | ARTICLES | V2_RESERVED | MULTI_WORD_RESERVED
 )
@@ -382,6 +392,8 @@ VERB_SIGNATURES: dict[str, list[str]] = {
     "expect":   ["condition"],
     # Infrastructure Era batch 2: `sort <target> by <field> [reverse]`.
     "sort":     ["target", "field"],
+    # V2 promotion: `compare <left> to <right>`.
+    "compare":  ["left", "right"],
 }
 
 

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -1,0 +1,311 @@
+"""Integration tests for the V2-promoted `compare` verb — sentences
+165–177. `compare <left> to <right>` infers comparison mode from operand
+types and stores a `comparison` record with `status` and `divergences`
+fields.
+
+Each test runs the program through the full pipeline via Session.run_line.
+"""
+
+from __future__ import annotations
+
+from liminate.cli import Session
+from liminate.result import ResultStatus
+
+
+def run_lines(lines):
+    session = Session()
+    results = [session.run_line(line) for line in lines]
+    return session, results
+
+
+# ---------------------------------------------------------------------------
+# Sentence 165 — compare identical records (match)
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_165_identical_records_match():
+    session, results = run_lines([
+        "remember an order called original with total as 75 and status as active",
+        "remember an order called copy with total as 75 and status as active",
+        "compare original to copy",
+        "show status of comparison",
+    ])
+    for r in results:
+        assert r.status is ResultStatus.SUCCESS, r.message
+    assert results[-1].output == ["match"]
+
+
+# ---------------------------------------------------------------------------
+# Sentence 166 — records differing on one field (mismatch)
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_166_one_field_differs():
+    session, results = run_lines([
+        "remember an order called v1 with total as 75 and status as active",
+        "remember an order called v2 with total as 75 and status as pending",
+        "compare v1 to v2",
+        "show status of comparison",
+        "show divergences of comparison",
+    ])
+    for r in results:
+        assert r.status is ResultStatus.SUCCESS, r.message
+    assert results[3].output == ["mismatch"]
+    assert results[4].output == ["status"]
+
+
+# ---------------------------------------------------------------------------
+# Sentence 167 — multiple fields differ (sorted divergences)
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_167_multiple_fields_differ():
+    session, results = run_lines([
+        "remember an order called old with total as 50 and status as pending",
+        "remember an order called new with total as 75 and status as active",
+        "compare old to new",
+        "show status of comparison",
+        "show divergences of comparison",
+    ])
+    for r in results:
+        assert r.status is ResultStatus.SUCCESS, r.message
+    assert results[3].output == ["mismatch"]
+    # sorted alphabetically: status, total
+    assert results[4].output == ["status, total"]
+
+
+# ---------------------------------------------------------------------------
+# Sentence 168 — extra field on one side
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_168_extra_field():
+    session, results = run_lines([
+        "remember an order called base with total as 75",
+        "remember an order called extended with total as 75 and priority as high",
+        "compare base to extended",
+        "show status of comparison",
+        "show divergences of comparison",
+    ])
+    for r in results:
+        assert r.status is ResultStatus.SUCCESS, r.message
+    assert results[3].output == ["mismatch"]
+    assert results[4].output == ["priority"]
+
+
+# ---------------------------------------------------------------------------
+# Sentence 169 — identical scalars (match)
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_169_identical_scalars():
+    session, results = run_lines([
+        "remember a value called x with 42",
+        "remember a value called y with 42",
+        "compare x to y",
+        "show status of comparison",
+    ])
+    for r in results:
+        assert r.status is ResultStatus.SUCCESS, r.message
+    assert results[-1].output == ["match"]
+
+
+# ---------------------------------------------------------------------------
+# Sentence 170 — different scalars (mismatch, empty divergences)
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_170_different_scalars():
+    session, results = run_lines([
+        "remember a value called x with 42",
+        "remember a value called y with 99",
+        "compare x to y",
+        "show status of comparison",
+        "show divergences of comparison",
+    ])
+    for r in results:
+        assert r.status is ResultStatus.SUCCESS, r.message
+    assert results[3].output == ["mismatch"]
+    # Empty divergences list renders as a single empty-string line.
+    assert results[4].output == [""]
+
+
+# ---------------------------------------------------------------------------
+# Sentence 171 — record vs scalar (type mismatch)
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_171_record_vs_scalar_type_mismatch():
+    session, results = run_lines([
+        "remember an order called o1 with total as 75",
+        "remember a value called x with 42",
+        "compare o1 to x",
+        "show status of comparison",
+    ])
+    for r in results:
+        assert r.status is ResultStatus.SUCCESS, r.message
+    assert results[-1].output == ["type_mismatch"]
+
+
+# ---------------------------------------------------------------------------
+# Sentence 172 — identical lists (match)
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_172_identical_lists():
+    session, results = run_lines([
+        "remember a list called nums-a with 1 and 2 and 3",
+        "remember a list called nums-b with 1 and 2 and 3",
+        "compare nums-a to nums-b",
+        "show status of comparison",
+    ])
+    for r in results:
+        assert r.status is ResultStatus.SUCCESS, r.message
+    assert results[-1].output == ["match"]
+
+
+# ---------------------------------------------------------------------------
+# Sentence 173 — lists with element difference (mismatch on index)
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_173_list_element_differs():
+    session, results = run_lines([
+        "remember a list called nums-a with 1 and 2 and 3",
+        "remember a list called nums-b with 1 and 99 and 3",
+        "compare nums-a to nums-b",
+        "show status of comparison",
+        "show divergences of comparison",
+    ])
+    for r in results:
+        assert r.status is ResultStatus.SUCCESS, r.message
+    assert results[3].output == ["mismatch"]
+    # Index 1 differs.
+    assert results[4].output == ["1"]
+
+
+# ---------------------------------------------------------------------------
+# Sentence 174 — lists of different length
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_174_lists_different_length():
+    session, results = run_lines([
+        "remember a list called short with 1 and 2",
+        "remember a list called longer with 1 and 2 and 3",
+        "compare short to longer",
+        "show status of comparison",
+    ])
+    for r in results:
+        assert r.status is ResultStatus.SUCCESS, r.message
+    assert results[-1].output == ["length_mismatch"]
+
+
+# ---------------------------------------------------------------------------
+# Sentence 175 — compare then branch with choose
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_175_compare_then_choose():
+    session, results = run_lines([
+        "remember an order called submitted with total as 75 and status as pending",
+        "remember an order called approved with total as 75 and status as active",
+        "compare submitted to approved",
+        'choose if status of comparison is equal to "match": show "identical" '
+        'otherwise show "different"',
+    ])
+    for r in results:
+        assert r.status is ResultStatus.SUCCESS, r.message
+    assert results[-1].output == ["different"]
+
+
+# ---------------------------------------------------------------------------
+# Sentence 176 — capture divergences into a list and count them
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_176_count_divergences():
+    session, results = run_lines([
+        "remember an order called v1 with total as 50 and status as pending and priority as low",
+        "remember an order called v2 with total as 75 and status as active and priority as low",
+        "compare v1 to v2",
+        "remember a list called diffs from divergences of comparison",
+        "count the diffs",
+    ])
+    for r in results:
+        assert r.status is ResultStatus.SUCCESS, r.message
+    # total and status differ; priority matches → 2 divergences.
+    assert results[-1].output == ["2"]
+
+
+# ---------------------------------------------------------------------------
+# Sentence 177 — second compare overwrites the first result
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_177_second_compare_overwrites():
+    session, results = run_lines([
+        "remember a value called x with 1",
+        "remember a value called y with 1",
+        "remember a value called z with 2",
+        "compare x to y",
+        "show status of comparison",
+        "compare x to z",
+        "show status of comparison",
+    ])
+    for r in results:
+        assert r.status is ResultStatus.SUCCESS, r.message
+    assert results[4].output == ["match"]
+    assert results[6].output == ["mismatch"]
+
+
+# ---------------------------------------------------------------------------
+# compare is now a verb (was V2-reserved)
+# ---------------------------------------------------------------------------
+
+
+def test_compare_reserved_category_is_verb():
+    from liminate.vocabulary import reserved_category, VERBS, V2_RESERVED
+
+    assert reserved_category("compare") == "verb"
+    assert "compare" in VERBS
+    assert "compare" not in V2_RESERVED
+
+
+def test_compare_rejected_as_a_name():
+    session, results = run_lines([
+        "remember a value called compare with 5",
+    ])
+    assert results[0].status is ResultStatus.ERROR_PARSE
+    assert "compare" in (results[0].message or "")
+    assert "verb" in (results[0].message or "")
+
+
+# ---------------------------------------------------------------------------
+# Analyzer — undefined operand
+# ---------------------------------------------------------------------------
+
+
+def test_compare_undefined_operand_errors():
+    session, results = run_lines([
+        "remember a value called x with 5",
+        "compare x to missing-name",
+    ])
+    assert results[0].status is ResultStatus.SUCCESS
+    assert results[1].status is ResultStatus.ERROR_SEMANTIC
+    assert "missing-name" in (results[1].message or "")
+
+
+# ---------------------------------------------------------------------------
+# Canonical rendering round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_compare_renders_canonically():
+    from liminate.lexer import tokenize
+    from liminate.parser import parse
+    from liminate.renderer import render
+
+    src = "compare order-a to order-b"
+    ast = parse(tokenize(src))
+    assert parse(tokenize(render(ast))) == ast

--- a/tests/test_vocabulary.py
+++ b/tests/test_vocabulary.py
@@ -17,14 +17,14 @@ from liminate.vocabulary import (
 
 
 def test_verb_count():
-    # 17 verbs: 16 + 1 (`sort` — Infrastructure Era batch 2 in-place
-    # list reordering by field).
-    assert len(VERBS) == 17
+    # 18 verbs: 17 + 1 (`compare` — V2 promotion; structured comparison
+    # of two domain values into a `comparison` result record).
+    assert len(VERBS) == 18
     assert VERBS == {
         "remember", "show", "filter", "keep", "count",
         "gather", "combine", "each", "choose", "finish",
         "add", "remove", "weakens", "require",
-        "assign", "expect", "sort",
+        "assign", "expect", "sort", "compare",
     }
 
 
@@ -64,11 +64,11 @@ def test_delimiter_count():
 
 
 def test_v2_reserved():
-    # v3a §124: 2 deferred verbs remaining. `when` and `unless` moved
-    # to CONNECTIVES in v3a §108/§109; `transform` and `compare`
-    # continue to be deferred per v2d §103 / v3a §124.
-    assert len(V2_RESERVED) == 2
-    assert V2_RESERVED == {"transform", "compare"}
+    # 1 deferred verb remaining. `when`/`unless` moved to CONNECTIVES in
+    # v3a §108/§109; the V2 promotion build moved `compare` to VERBS.
+    # `transform` continues to be deferred.
+    assert len(V2_RESERVED) == 1
+    assert V2_RESERVED == {"transform"}
 
 
 def test_multi_word_reserved():
@@ -78,9 +78,10 @@ def test_multi_word_reserved():
 
 
 def test_total_reserved_count_is_51():
-    # 51 reserved words total (Infrastructure Era batch 2). 17 verbs +
+    # 51 reserved words total (unchanged by the V2 promotion — `compare`
+    # moved category, not in/out of the reserved set). 18 verbs +
     # 19 connectives + 7 operators + 3 multi-word + 3 articles +
-    # 2 v2-deferred verbs = 51.
+    # 1 v2-deferred verb = 51.
     assert len(ALL_RESERVED) == 51
 
 
@@ -147,6 +148,8 @@ def test_verb_signature_slot_shapes():
     assert VERB_SIGNATURES["expect"] == ["condition"]
     # Infrastructure Era batch 2: `sort <target> by <field>`.
     assert VERB_SIGNATURES["sort"] == ["target", "field"]
+    # V2 promotion: `compare <left> to <right>`.
+    assert VERB_SIGNATURES["compare"] == ["left", "right"]
 
 
 def test_add_is_classified_as_verb():


### PR DESCRIPTION
## Summary

Promotes `compare` from `V2_RESERVED` to an active base verb. Both historical blockers are resolved: `choose` exists (branching era) and the return value is now specified as a structured record (Option C). Grammar: `compare <left> to <right>`. The verb infers comparison mode from operand types and stores a `comparison` record with `status` (string) and `divergences` (list) fields. Silent — result stored only.

Comparison modes:
- **record vs record** → structural; `divergences` = sorted diverging field names
- **list vs list** → structural; `divergences` = diverging indices (`length_mismatch` when lengths differ)
- **container vs a different shape / scalar** → `type_mismatch`
- **scalar vs scalar** → equality; `divergences` = `[]`

## Phases completed
Vocabulary · Parser · Analyzer · Interpreter · Renderer · Tests.

## Files
**Modified:** `src/liminate/{vocabulary,parser,analyzer,interpreter,renderer}.py`, `tests/test_vocabulary.py`.
**Created:** `tests/test_compare.py`.

## Invariants satisfied (§7)
1. `compare` in VERBS, not V2_RESERVED ✓
2. `compare` in VERB_SIGNATURES (`[left, right]`) ✓
3. `comparison` stored as a plain dict — `of` field access works ✓
4. `divergences` always a list (even empty / type_mismatch / length_mismatch) ✓
5. `status` always one of `match` / `mismatch` / `type_mismatch` / `length_mismatch` ✓
6. Field-name divergences sorted alphabetically (deterministic) ✓

Total reserved words unchanged at 51 (verbs 17→18, V2-reserved 2→1). DecayingValue operands resolve to their current value before comparison.

## Tests
1034 pass (was 1017 → +17):
- 13 sentence-style integration tests (165–177): identical/divergent records, extra-field, scalars, type_mismatch, list match/mismatch/length_mismatch, **compare + choose branching**, divergence capture + count, result overwrite.
- `compare` reserved-category now `verb`; rejected as a variable name; undefined-operand semantic error; canonical round-trip.
- Vocabulary tests updated: 18 verbs, `V2_RESERVED = {transform}`, total 51.

Also fixed `show <field> of <record>` to use the list display format when the field is a list, so `show divergences of comparison` reads as `status, total` rather than Python's `['status', 'total']` repr.

## Structured result confirmed
- Identical records → `match`, `[]` ✓
- One field differs → `mismatch`, `status` ✓
- Multiple fields → `mismatch`, `status, total` (sorted) ✓
- Record vs scalar → `type_mismatch` ✓
- Lists differing element → `mismatch`, index `1` ✓
- Lists of different length → `length_mismatch` ✓
- `compare` + `choose if status of comparison is equal to "match"` → branches correctly (`different`) ✓

## Test plan
- [x] `pytest tests/` — 1034 pass
- [x] All four statuses tested (match, mismatch, type_mismatch, length_mismatch)
- [x] `of` field access for both `status` and `divergences`
- [x] `choose` integration (sentence 175)
- [x] No stale "reserved word" assertions for `compare`

🤖 Generated with [Claude Code](https://claude.com/claude-code)