### PR TITLE
feat: promote `transform` from V2-reserved to base verb — V2_RESERVED is now empty (18 → 19 verbs)

### DIFF
--- a/src/liminate/analyzer.py
+++ b/src/liminate/analyzer.py
@@ -81,6 +81,7 @@ from .parser import (
     SequenceNode,
     ShowNode,
     SortNode,
+    TransformNode,
     WeakensNode,
     WhenNode,
 )
@@ -336,6 +337,8 @@ def _check(
         _check_sort(node, symtab, live_value_names=live_value_names)
     elif isinstance(node, CompareNode):
         _check_compare(node, symtab)
+    elif isinstance(node, TransformNode):
+        _check_transform(node, symtab, live_value_names=live_value_names)
     elif isinstance(node, FinishNode):
         # v3a §112: `finish` is legal only inside a `when` action block
         # (directly, in a `choose` branch, or in a composition called
@@ -516,6 +519,10 @@ def _side_effect_verb(
         # V2 promotion — `compare` stores the `comparison` record as a
         # side effect; the verb phrase itself produces no value.
         return "compare"
+    if isinstance(node, TransformNode):
+        # Final V2 promotion — `transform` mutates the list in place;
+        # returns no value.
+        return "transform"
     if isinstance(node, (RememberListNode, RememberRecordNode, RememberCompositionNode)):
         return "remember"
     if isinstance(node, RememberValueNode):
@@ -950,6 +957,51 @@ def _check_sort(
             f"I can only sort a list. '{name}' is {_singular(entry.type)}."
         )
     if entry.type == "list_of_records" and entry.value:
+        iterator = _make_iterator(name, entry)
+        if iterator.record_schemas is not None:
+            in_all = all(node.field in s for s in iterator.record_schemas)
+            if not in_all:
+                raise _SemanticError(
+                    _schema_mismatch_message(
+                        entry, iterator.record_schemas, node.field,
+                    )
+                )
+
+
+def _check_transform(
+    node: TransformNode,
+    symtab: dict[str, SymbolEntry],
+    *,
+    live_value_names: set[str] | None = None,
+) -> None:
+    """Final V2 promotion — validate the `transform` verb.
+
+    1. Transform is destructive (in-place), so adapter-owned live values
+       can't be transformed.
+    2. Target must exist and be a list.
+    3. Record-field mode (field set): for a known list_of_records, the
+       field must exist on every record's schema.
+    4. The expression itself is validated per-element at runtime (it may
+       reference fields on the current record); the analyzer defers
+       expression type-checking to the interpreter's numeric guards.
+    """
+    name = node.target.name
+    if live_value_names and name in live_value_names:
+        raise _SemanticError(
+            f"'{name}' is a live value provided by the domain pack. "
+            f"'transform' is destructive and can't modify it."
+        )
+    if name not in symtab:
+        raise _SemanticError(
+            f"I can't find '{name}'. "
+            f"You might need to 'remember' it first."
+        )
+    entry = symtab[name]
+    if entry.type not in ("list_of_numbers", "list_of_strings", "list_of_records"):
+        raise _SemanticError(
+            f"I can only transform a list. '{name}' is {_singular(entry.type)}."
+        )
+    if node.field is not None and entry.type == "list_of_records" and entry.value:
         iterator = _make_iterator(name, entry)
         if iterator.record_schemas is not None:
             in_all = all(node.field in s for s in iterator.record_schemas)

--- a/src/liminate/interpreter.py
+++ b/src/liminate/interpreter.py
@@ -95,6 +95,7 @@ from .parser import (
     SequenceNode,
     ShowNode,
     SortNode,
+    TransformNode,
     WeakensNode,
     WhenNode,
 )
@@ -570,6 +571,8 @@ def _exec_op(
         return _exec_sort(node, symtab)
     if isinstance(node, CompareNode):
         return _exec_compare(node, symtab, current_item)
+    if isinstance(node, TransformNode):
+        return _exec_transform(node, symtab)
     if isinstance(node, FinishNode):
         # v3a §112 — immediate and total. The exception unwinds out of
         # any surrounding choose/sequence/composition straight to the
@@ -1067,6 +1070,54 @@ def _exec_sort(node: SortNode, symtab: dict[str, SymbolEntry]) -> list[str]:
             f"I can't sort '{node.target.name}' by '{node.field}' — "
             f"the values are a mix of types that can't be compared."
         )
+    return []
+
+
+def _exec_transform(
+    node: TransformNode,
+    symtab: dict[str, SymbolEntry],
+) -> list[str]:
+    """Final V2 promotion — per-element in-place list mutation.
+
+    Record-field mode (`node.field` set): re-evaluate the expression for
+    each record with that record as the iterator context and write the
+    result back to the named field. Scalar-list mode (`node.field` None):
+    re-evaluate the expression with the current scalar element as the
+    iterator context (the `each` pronoun resolves to it) and replace the
+    element.
+
+    The per-element evaluator is `_eval_arithmetic_operand`, which
+    resolves a bare field name against the current record dict and
+    delegates everything else (arithmetic, field access, the `each`
+    pronoun, symbol-table names) to `_evaluate_expression` — the same
+    iterator-context resolution `each`/`where`/`add` use. Silent.
+    """
+    entry = symtab[node.target.name]
+    the_list = entry.value
+    if not the_list:
+        return []
+
+    if node.field is not None:
+        for i, item in enumerate(the_list):
+            if not isinstance(item, dict):
+                raise _RuntimeError(
+                    f"I can only transform fields on records. "
+                    f"Item {i + 1} in '{node.target.name}' is "
+                    f"{_format_scalar(item)}."
+                )
+            if node.field not in item:
+                raise _RuntimeError(
+                    f"Record {i + 1} in '{node.target.name}' doesn't "
+                    f"have a field called '{node.field}'."
+                )
+            item[node.field] = _eval_arithmetic_operand(
+                node.expression, symtab, item,
+            )
+    else:
+        for i in range(len(the_list)):
+            the_list[i] = _eval_arithmetic_operand(
+                node.expression, symtab, the_list[i],
+            )
     return []
 
 

--- a/src/liminate/parser.py
+++ b/src/liminate/parser.py
@@ -415,6 +415,27 @@ class CompareNode(ASTNode):
 
 
 @dataclass
+class TransformNode(ASTNode):
+    """Final V2 promotion — per-element list mutation.
+
+    Two modes, distinguished by whether `field` is set:
+    - Record-field mode (`field` is not None): modifies the named field
+      on each record in `target`. Grammar: `transform <field> of
+      <target> by <expression>`.
+    - Scalar-list mode (`field` is None): replaces each scalar element
+      in `target` with the expression result. Grammar: `transform
+      <target> by <expression>`.
+
+    `expression` is evaluated per element with iterator context — names
+    resolve against the current element first, then the symbol table
+    (v1c §49).
+    """
+    target: NameRef
+    expression: ASTNode
+    field: str | None = None
+
+
+@dataclass
 class ExpectNode(ASTNode):
     """Epistemic Era batch 3 — tracked anticipation verb.
 
@@ -809,6 +830,8 @@ def _parse_verb_statement(stream: TokenStream, comp: set[str]) -> ASTNode:
         return _parse_sort(stream)
     if verb.value == "compare":
         return _parse_compare(stream)
+    if verb.value == "transform":
+        return _parse_transform(stream)
     if verb.value == "finish":
         # v3a §112 — slot-less verb. Phase 1 semantic check (in the
         # analyzer) rejects calls outside an action-block context; here
@@ -1623,6 +1646,99 @@ def _parse_compare(stream: TokenStream) -> CompareNode:
 
 
 # ---------------------------------------------------------------------------
+# transform (final V2 promotion)
+# ---------------------------------------------------------------------------
+
+
+def _parse_transform(stream: TokenStream) -> TransformNode:
+    """`transform <field> of <target> by <expression>`  (record-field mode)
+    or `transform <target> by <expression>`             (scalar-list mode).
+
+    Disambiguation: after consuming the first name, peek for `of`. If
+    present, the first name is the field and the name after `of` is the
+    target (record-field mode). If absent, the first name is the target
+    (scalar-list mode).
+    """
+    _consume_optional_article(stream)
+    if stream.at_end():
+        raise _ParseError(
+            "'transform' needs a target — try: "
+            "transform <list> by <expression>, or "
+            "transform <field> of <list> by <expression>."
+        )
+
+    first_tok = stream.consume()
+    if first_tok is None:
+        raise _ParseError("I expected a name after 'transform'.")
+    if first_tok.type is TokenType.QUOTED_STRING:
+        raise _ParseError(
+            f"Names can't have spaces. Try a hyphenated name like "
+            f"'{_hyphenate(first_tok.value)}' instead."
+        )
+    if first_tok.type is not TokenType.UNKNOWN:
+        cat = reserved_category(first_tok.value)
+        if cat:
+            raise _ParseError(
+                f"The word '{first_tok.value}' is reserved in Liminate "
+                f"— it's used as a {cat}. Please use a name you've "
+                f"created."
+            )
+        raise _ParseError(
+            f"I expected a name after 'transform', not '{first_tok.value}'."
+        )
+
+    peek = stream.peek()
+
+    if peek and peek.type is TokenType.CONNECTIVE and peek.value == "of":
+        # Record-field mode: first_tok is the field name.
+        stream.consume()  # eat `of`
+        _consume_optional_article(stream)
+        target = _consume_target(stream, verb="transform")
+        field_name = first_tok.value
+
+        by_tok = stream.consume()
+        if not (
+            by_tok
+            and by_tok.type is TokenType.CONNECTIVE
+            and by_tok.value == "by"
+        ):
+            raise _ParseError(
+                "'transform' needs an expression after 'by' — try: "
+                f"transform {field_name} of {target.name} by <expression>."
+            )
+        if stream.at_end():
+            raise _ParseError("I expected an expression after 'by'.")
+        stream.push_clause("transform")
+        try:
+            expression = _parse_value(stream)
+        finally:
+            stream.pop_clause()
+        return TransformNode(
+            target=target, expression=expression, field=field_name,
+        )
+
+    if peek and peek.type is TokenType.CONNECTIVE and peek.value == "by":
+        # Scalar-list mode: first_tok is the target.
+        stream.consume()  # eat `by`
+        target = NameRef(name=first_tok.value)
+        if stream.at_end():
+            raise _ParseError("I expected an expression after 'by'.")
+        stream.push_clause("transform")
+        try:
+            expression = _parse_value(stream)
+        finally:
+            stream.pop_clause()
+        return TransformNode(target=target, expression=expression, field=None)
+
+    got = peek.value if peek else "end of line"
+    raise _ParseError(
+        f"I expected 'of' or 'by' after 'transform {first_tok.value}', "
+        f"not '{got}'. Try: transform {first_tok.value} of <list> by "
+        f"<expression>, or transform {first_tok.value} by <expression>."
+    )
+
+
+# ---------------------------------------------------------------------------
 # gather
 # ---------------------------------------------------------------------------
 
@@ -2027,6 +2143,18 @@ def _parse_atom(stream: TokenStream) -> ASTNode:
                 f"instead of \"{tok.value}\"."
             )
         return QuotedString(content=tok.value)
+    # Final V2 promotion: allow `each` as a self-reference pronoun in
+    # value position inside a `transform` clause (scalar-list mode), the
+    # same way it acts as a pronoun inside a `where` condition (v1b §37).
+    # It resolves to the current element during per-element evaluation.
+    if tok.type is TokenType.VERB and tok.value == "each":
+        if stream.in_clause("transform"):
+            return EachPronoun()
+        raise _ParseError(
+            "'each' is a verb in Liminate — it iterates a list, or "
+            "acts as a self-reference pronoun inside a 'where' "
+            "clause. It can't appear as a value on its own."
+        )
     cat = reserved_category(tok.value)
     if cat:
         raise _ParseError(

--- a/src/liminate/renderer.py
+++ b/src/liminate/renderer.py
@@ -57,6 +57,7 @@ from .parser import (
     SequenceNode,
     ShowNode,
     SortNode,
+    TransformNode,
     WeakensNode,
     WhenNode,
 )
@@ -215,6 +216,16 @@ def render(node: ASTNode) -> str:
     if isinstance(node, CompareNode):
         # V2 promotion — `compare <left> to <right>`.
         return f"compare {render(node.left)} to {render(node.right)}"
+    if isinstance(node, TransformNode):
+        # Final V2 promotion — record-field mode renders the `<field> of`
+        # prefix; scalar-list mode omits it.
+        expr_str = render(node.expression)
+        if node.field is not None:
+            return (
+                f"transform {node.field} of {render(node.target)} "
+                f"by {expr_str}"
+            )
+        return f"transform {render(node.target)} by {expr_str}"
 
     if isinstance(node, PackVerbNode):
         # v4a §137 + v2: pack verbs render as `<word> [<conn>] <value>...`

--- a/src/liminate/vocabulary.py
+++ b/src/liminate/vocabulary.py
@@ -41,6 +41,10 @@ Sources:
 - V2 promotion: `compare` (18 verbs, 51 reserved words total) —
   structured comparison of two domain values, producing a record
   named `comparison` with `status` and `divergences` fields.
+- Final V2 promotion: `transform` (19 verbs, 0 V2-reserved, 51
+  reserved words total) — per-element list mutation via arithmetic
+  expressions. V2_RESERVED is now empty; all originally deferred
+  words have been promoted.
 """
 
 from dataclasses import dataclass
@@ -95,6 +99,11 @@ VERBS: frozenset[str] = frozenset({
     # result record named `comparison` with `status` and `divergences`
     # fields. Comparison mode inferred from operand types.
     "compare",
+    # Final V2 promotion: `transform` modifies elements of a list
+    # in place. Two modes: record-field (`transform <field> of <list>
+    # by <expr>`) and scalar (`transform <list> by <expr>`). Expression
+    # evaluated per element with iterator context.
+    "transform",
 })
 
 # v1 / v2a / v2d / v3a connectives. v2a §68 added `of`. v2d §99 added
@@ -143,14 +152,13 @@ ARTICLES: frozenset[str] = frozenset({
 DELIMITERS: frozenset[str] = frozenset({":"})
 
 # v2 deferred words — designed but not executable in v1. Reserved so
-# user programs that use them as names will not silently break when v2
-# ships (v1a §29). v2d §99 promoted `choose` to an active verb. v3a §108
-# promoted `when` and `unless` to active connectives. The V2 promotion
-# build moved `compare` to an active verb (structured comparison with a
-# `comparison` result record); `transform` continues to be deferred.
-V2_RESERVED: frozenset[str] = frozenset({
-    "transform",
-})
+# user programs that use them as names would not silently break when v2
+# ships (v1a §29). All original V2-deferred words have now been promoted
+# to active verbs/connectives: `choose` (v2d §99), `when`/`unless`
+# (v3a §108/§109), `compare` (V2 promotion), `transform` (final V2
+# promotion). The frozenset is retained empty as a structural
+# placeholder — future deferrals would go here.
+V2_RESERVED: frozenset[str] = frozenset()
 
 # `equal` is the multi-word lookahead trigger for `equal to`. Reserved
 # independently — allowing it as a name would make the lexer's behavior
@@ -163,8 +171,8 @@ MULTI_WORD_RESERVED: frozenset[str] = frozenset({
     "multiplied", "divided",
 })
 
-# All 51 reserved words. 18 verbs, 19 connectives, 7 operators, 3
-# articles, 1 V2-reserved, 3 multi-word reserved. v3a §124 was 34
+# All 51 reserved words. 19 verbs, 19 connectives, 7 operators, 3
+# articles, 0 V2-reserved, 3 multi-word reserved. v3a §124 was 34
 # (+1 for `finish`). Liminate `add` verb addendum v1 §9: +1 for `add`
 # (appends an item to a list). `includes` connective + `remove` verb
 # addendum: +2 (list membership test in conditions, retract item from a
@@ -180,7 +188,9 @@ MULTI_WORD_RESERVED: frozenset[str] = frozenset({
 # +2 — `sort` verb (in-place list reordering by a field) and `reverse`
 # operator (descending sort modifier). V2 promotion: +0 net — `compare`
 # moved from V2_RESERVED to VERBS, so the verb count rose to 18 and the
-# V2-reserved count fell to 1; the total stays 51.
+# V2-reserved count fell to 1; the total stays 51. Final V2 promotion:
+# +0 net — `transform` moved from V2_RESERVED to VERBS (verbs 18→19,
+# V2-reserved 1→0); the total stays 51 and V2_RESERVED is now empty.
 ALL_RESERVED: frozenset[str] = (
     VERBS | CONNECTIVES | OPERATORS | ARTICLES | V2_RESERVED | MULTI_WORD_RESERVED
 )
@@ -196,7 +206,8 @@ def reserved_category(word: str) -> str | None:
     v4a §137: active pack verbs report as "verb"; active pack nouns
     report as "noun". Pack words are only reserved while the pack that
     declared them is loaded — the base vocabulary is the canonical
-    surface (currently 51 reserved words; see module docstring).
+    surface (currently 51 reserved words — 19 verbs, 0 V2-reserved;
+    see module docstring).
     """
     if word in VERBS:
         return "verb"
@@ -394,6 +405,9 @@ VERB_SIGNATURES: dict[str, list[str]] = {
     "sort":     ["target", "field"],
     # V2 promotion: `compare <left> to <right>`.
     "compare":  ["left", "right"],
+    # Final V2 promotion: `transform <field> of <target> by <expression>`
+    # or `transform <target> by <expression>`.
+    "transform": ["target", "expression"],
 }
 
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,0 +1,339 @@
+"""Integration tests for the final V2-promoted `transform` verb —
+sentences 178–192. `transform` mutates list elements in place in two
+modes: record-field (`transform <field> of <list> by <expr>`) and
+scalar-list (`transform <list> by <expr>`). The expression is evaluated
+per element with iterator context.
+
+Each test runs the program through the full pipeline via Session.run_line.
+"""
+
+from __future__ import annotations
+
+from liminate.cli import Session
+from liminate.result import ResultStatus
+
+
+def run_lines(lines):
+    session = Session()
+    results = [session.run_line(line) for line in lines]
+    return session, results
+
+
+# ---------------------------------------------------------------------------
+# Sentence 178 — record-field: subtract a constant
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_178_record_field_subtract_constant():
+    session, results = run_lines([
+        "remember an order called o1 with total as 100",
+        "remember an order called o2 with total as 200",
+        "remember a list called orders with o1 and o2",
+        "transform total of the orders by total minus 10",
+        "each the orders show total",
+    ])
+    for r in results:
+        assert r.status is ResultStatus.SUCCESS, r.message
+    assert results[-1].output == ["90", "190"]
+
+
+# ---------------------------------------------------------------------------
+# Sentence 179 — record-field: multiply by a fraction (discount)
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_179_record_field_multiply_fraction():
+    session, results = run_lines([
+        "remember an item called i1 with price as 100",
+        "remember an item called i2 with price as 50",
+        "remember a list called items with i1 and i2",
+        "transform price of the items by price multiplied by 0.9",
+        "each the items show price",
+    ])
+    for r in results:
+        assert r.status is ResultStatus.SUCCESS, r.message
+    # 100*0.9 = 90.0 and 50*0.9 = 45.0, displayed as whole numbers per
+    # Liminate's _format_scalar convention (whole floats render as ints,
+    # same as `10 divided by 2` → `5`).
+    assert results[-1].output == ["90", "45"]
+
+
+# ---------------------------------------------------------------------------
+# Sentence 180 — record-field: use a symbol-table variable
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_180_record_field_symbol_variable():
+    session, results = run_lines([
+        "remember a value called discount with 15",
+        "remember an order called o1 with total as 100",
+        "remember an order called o2 with total as 75",
+        "remember a list called orders with o1 and o2",
+        "transform total of the orders by total minus discount",
+        "each the orders show total",
+    ])
+    for r in results:
+        assert r.status is ResultStatus.SUCCESS, r.message
+    assert results[-1].output == ["85", "60"]
+
+
+# ---------------------------------------------------------------------------
+# Sentence 181 — record-field: preserves other fields
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_181_record_field_preserves_others():
+    session, results = run_lines([
+        "remember an order called o1 with total as 100 and status as active",
+        "remember a list called orders with o1",
+        "transform total of the orders by total plus 50",
+        "each the orders show total and status",
+    ])
+    for r in results:
+        assert r.status is ResultStatus.SUCCESS, r.message
+    assert results[-1].output == ["total: 150, status: active"]
+
+
+# ---------------------------------------------------------------------------
+# Sentence 182 — scalar-list: add a constant
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_182_scalar_add_constant():
+    session, results = run_lines([
+        "remember a list called scores with 10 and 20 and 30",
+        "transform the scores by each plus 5",
+        "show scores",
+    ])
+    for r in results:
+        assert r.status is ResultStatus.SUCCESS, r.message
+    assert results[-1].output == ["15, 25, 35"]
+
+
+# ---------------------------------------------------------------------------
+# Sentence 183 — scalar-list: multiply
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_183_scalar_multiply():
+    session, results = run_lines([
+        "remember a list called prices with 100 and 200 and 50",
+        "transform prices by each multiplied by 2",
+        "show prices",
+    ])
+    for r in results:
+        assert r.status is ResultStatus.SUCCESS, r.message
+    assert results[-1].output == ["200, 400, 100"]
+
+
+# ---------------------------------------------------------------------------
+# Sentence 184 — scalar-list: subtract
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_184_scalar_subtract():
+    session, results = run_lines([
+        "remember a list called values with 50 and 30 and 10",
+        "transform the values by each minus 5",
+        "show values",
+    ])
+    for r in results:
+        assert r.status is ResultStatus.SUCCESS, r.message
+    assert results[-1].output == ["45, 25, 5"]
+
+
+# ---------------------------------------------------------------------------
+# Sentence 185 — transform then show (operation sequence)
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_185_transform_then_show_sequence():
+    session, results = run_lines([
+        "remember an order called o1 with total as 100",
+        "remember an order called o2 with total as 50",
+        "remember a list called orders with o1 and o2",
+        "transform total of the orders by total plus 25 and each the orders show total",
+    ])
+    for r in results:
+        assert r.status is ResultStatus.SUCCESS, r.message
+    assert results[-1].output == ["125", "75"]
+
+
+# ---------------------------------------------------------------------------
+# Sentence 186 — transform then sort (composition)
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_186_transform_then_sort():
+    session, results = run_lines([
+        "remember an order called o1 with total as 100",
+        "remember an order called o2 with total as 200",
+        "remember an order called o3 with total as 50",
+        "remember a list called orders with o1 and o2 and o3",
+        "transform total of the orders by total multiplied by 2",
+        "sort the orders by total",
+        "each the orders show total",
+    ])
+    for r in results:
+        assert r.status is ResultStatus.SUCCESS, r.message
+    assert results[-1].output == ["100", "200", "400"]
+
+
+# ---------------------------------------------------------------------------
+# Sentence 187 — transform empty list (no error)
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_187_transform_empty_list_noop():
+    session, results = run_lines([
+        "remember an order called o1 with total as 999",
+        "remember a list called orders with o1",
+        "filter the orders where total is above 10000",
+        "transform total of the orders by total plus 1",
+        "count the orders",
+    ])
+    for r in results:
+        assert r.status is ResultStatus.SUCCESS, r.message
+    assert results[-1].output == ["0"]
+
+
+# ---------------------------------------------------------------------------
+# Sentence 188 — transform non-record in field mode (error)
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_188_transform_non_record_errors():
+    session, results = run_lines([
+        "remember a list called nums with 1 and 2 and 3",
+        "transform total of the nums by total plus 1",
+    ])
+    assert results[0].status is ResultStatus.SUCCESS, results[0].message
+    assert results[1].status is ResultStatus.ERROR_SEMANTIC
+    assert "records" in (results[1].message or "")
+
+
+# ---------------------------------------------------------------------------
+# Sentence 189 — transform missing field (error)
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_189_transform_missing_field_errors():
+    session, results = run_lines([
+        "remember an order called o1 with total as 100",
+        "remember a list called orders with o1",
+        "transform missing-field of the orders by missing-field plus 1",
+    ])
+    for r in results[:2]:
+        assert r.status is ResultStatus.SUCCESS, r.message
+    assert results[-1].status is ResultStatus.ERROR_SEMANTIC
+    assert "missing-field" in (results[-1].message or "")
+
+
+# ---------------------------------------------------------------------------
+# Sentence 190 — transform with PEMDAS in expression
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_190_transform_pemdas_expression():
+    session, results = run_lines([
+        "remember a value called base with 10",
+        "remember a value called rate with 2",
+        "remember an order called o1 with total as 100",
+        "remember a list called orders with o1",
+        "transform total of the orders by total plus base multiplied by rate",
+        "each the orders show total",
+    ])
+    for r in results:
+        assert r.status is ResultStatus.SUCCESS, r.message
+    # base * rate = 20, then total + 20 = 120 (PEMDAS).
+    assert results[-1].output == ["120"]
+
+
+# ---------------------------------------------------------------------------
+# Sentence 191 — transform with field access in expression
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_191_transform_field_access_expression():
+    session, results = run_lines([
+        "remember an order called o1 with price as 100 and quantity as 3",
+        "remember a list called orders with o1",
+        "transform price of the orders by price multiplied by quantity",
+        "each the orders show price",
+    ])
+    for r in results:
+        assert r.status is ResultStatus.SUCCESS, r.message
+    # Both `price` and `quantity` resolve against the current record.
+    assert results[-1].output == ["300"]
+
+
+# ---------------------------------------------------------------------------
+# Sentence 192 — scalar transform with division
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_192_scalar_division():
+    session, results = run_lines([
+        "remember a list called amounts with 100 and 200 and 50",
+        "transform the amounts by each divided by 2",
+        "show amounts",
+    ])
+    for r in results:
+        assert r.status is ResultStatus.SUCCESS, r.message
+    assert results[-1].output == ["50, 100, 25"]
+
+
+# ---------------------------------------------------------------------------
+# transform is now a verb; V2_RESERVED is empty
+# ---------------------------------------------------------------------------
+
+
+def test_transform_reserved_category_is_verb():
+    from liminate.vocabulary import reserved_category, VERBS, V2_RESERVED
+
+    assert reserved_category("transform") == "verb"
+    assert "transform" in VERBS
+    assert "transform" not in V2_RESERVED
+    assert len(V2_RESERVED) == 0
+
+
+def test_transform_rejected_as_a_name():
+    session, results = run_lines([
+        "remember a value called transform with 5",
+    ])
+    assert results[0].status is ResultStatus.ERROR_PARSE
+    assert "transform" in (results[0].message or "")
+    assert "verb" in (results[0].message or "")
+
+
+# ---------------------------------------------------------------------------
+# Missing `by` / `of`-or-`by` errors
+# ---------------------------------------------------------------------------
+
+
+def test_transform_missing_by_errors():
+    session, results = run_lines([
+        "remember an order called o1 with total as 100",
+        "remember a list called orders with o1",
+        "transform total of the orders",
+    ])
+    assert results[-1].status is ResultStatus.ERROR_PARSE
+    assert "by" in (results[-1].message or "")
+
+
+# ---------------------------------------------------------------------------
+# Canonical rendering round-trip (both modes)
+# ---------------------------------------------------------------------------
+
+
+def test_transform_renders_canonically():
+    from liminate.lexer import tokenize
+    from liminate.parser import parse
+    from liminate.renderer import render
+
+    for src in (
+        "transform total of the orders by total minus discount",
+        "transform the numbers by each plus 10",
+    ):
+        ast = parse(tokenize(src))
+        assert parse(tokenize(render(ast))) == ast

--- a/tests/test_vocabulary.py
+++ b/tests/test_vocabulary.py
@@ -17,14 +17,14 @@ from liminate.vocabulary import (
 
 
 def test_verb_count():
-    # 18 verbs: 17 + 1 (`compare` — V2 promotion; structured comparison
-    # of two domain values into a `comparison` result record).
-    assert len(VERBS) == 18
+    # 19 verbs: 18 + 1 (`transform` — final V2 promotion; per-element
+    # list mutation via arithmetic expressions).
+    assert len(VERBS) == 19
     assert VERBS == {
         "remember", "show", "filter", "keep", "count",
         "gather", "combine", "each", "choose", "finish",
         "add", "remove", "weakens", "require",
-        "assign", "expect", "sort", "compare",
+        "assign", "expect", "sort", "compare", "transform",
     }
 
 
@@ -64,11 +64,11 @@ def test_delimiter_count():
 
 
 def test_v2_reserved():
-    # 1 deferred verb remaining. `when`/`unless` moved to CONNECTIVES in
-    # v3a §108/§109; the V2 promotion build moved `compare` to VERBS.
-    # `transform` continues to be deferred.
-    assert len(V2_RESERVED) == 1
-    assert V2_RESERVED == {"transform"}
+    # V2_RESERVED is now empty. All originally deferred words have been
+    # promoted: `choose` (v2d §99), `when`/`unless` (v3a §108/§109),
+    # `compare` (V2 promotion), `transform` (final V2 promotion).
+    assert len(V2_RESERVED) == 0
+    assert V2_RESERVED == frozenset()
 
 
 def test_multi_word_reserved():
@@ -78,10 +78,10 @@ def test_multi_word_reserved():
 
 
 def test_total_reserved_count_is_51():
-    # 51 reserved words total (unchanged by the V2 promotion — `compare`
-    # moved category, not in/out of the reserved set). 18 verbs +
-    # 19 connectives + 7 operators + 3 multi-word + 3 articles +
-    # 1 v2-deferred verb = 51.
+    # 51 reserved words total (unchanged by the final V2 promotion —
+    # `transform` moved category, not in/out of the reserved set).
+    # 19 verbs + 19 connectives + 7 operators + 3 multi-word +
+    # 3 articles + 0 v2-deferred = 51.
     assert len(ALL_RESERVED) == 51
 
 
@@ -150,6 +150,8 @@ def test_verb_signature_slot_shapes():
     assert VERB_SIGNATURES["sort"] == ["target", "field"]
     # V2 promotion: `compare <left> to <right>`.
     assert VERB_SIGNATURES["compare"] == ["left", "right"]
+    # Final V2 promotion: `transform <target> by <expression>`.
+    assert VERB_SIGNATURES["transform"] == ["target", "expression"]
 
 
 def test_add_is_classified_as_verb():


### PR DESCRIPTION
## Summary

Promotes `transform` from `V2_RESERVED` to an active base verb. The earlier ambiguity ("transform the prices with a discount" — *how?*) is resolved: `transform` uses the `by` connective (PR #11) followed by an arithmetic expression (PR #11). This is **the last word in `V2_RESERVED`** — after this build the frozenset is empty for the first time since the inception checkpoint. Every word ever designed, deferred, or reserved has been built.

Two grammar modes, disambiguated by `of`:
- **record-field:** `transform <field> of <list> by <expression>` — modifies the named field on each record.
- **scalar-list:** `transform <list> by <expression>` — replaces each scalar element; the `each` pronoun resolves to the current value.

In-place mutation (like `filter`/`sort`). Silent. The expression is evaluated per element with iterator context — field names resolve against the current record first, then the symbol table (v1c §49).

## Phases completed
Vocabulary · Parser · Analyzer · Interpreter · Renderer · Tests.

## Files
**Modified:** `src/liminate/{vocabulary,parser,analyzer,interpreter,renderer}.py`, `tests/test_vocabulary.py`.
**Created:** `tests/test_transform.py`.

## Invariants satisfied (§7)
1. `transform` in VERBS, not V2_RESERVED ✓
2. `V2_RESERVED` empty after this build ✓
3. `transform` in VERB_SIGNATURES (`[target, expression]`) ✓
4. In-place mutation — list reordered/rewritten in the symbol table ✓
5. Iterator context matches `each`/`where` (bare field names → current record; `each` → current scalar) ✓
6. `by` remains in CONNECTIVES ✓
7. `of` remains in CONNECTIVES ✓

Total reserved words unchanged at 51 (verbs 18→19, V2-reserved 1→0).

**Critical integration (Failure Mode 5):** `_parse_atom` previously rejected `each` in value position. Added handling so `each` parses as an `EachPronoun` when inside a `transform` clause (pushed via `stream.push_clause("transform")`), enabling scalar-list expressions like `each plus 5`. `_evaluate_expression` already resolves `EachPronoun → current_item`, including scalar items.

## Tests
1053 pass (was 1034 → +19):
- 15 sentence-style integration tests (178–192): record-field subtract/multiply/symbol-var/field-preservation; scalar add/multiply/subtract/divide; transform+show sequence; **transform+sort composition**; empty-list no-op; non-record error; missing-field error; **PEMDAS in expression**; **field access in expression**.
- `transform` reserved-category now `verb`; `V2_RESERVED` empty; rejected as a name; missing-`by` error; canonical round-trip (both modes).
- Vocabulary tests: 19 verbs, `V2_RESERVED = frozenset()`, total 51.

## Both modes confirmed
- Record-field: `transform total of the orders by total minus 10` (100, 200) → `90`, `190` ✓
- Record-field + symbol var: `total minus discount` → `85`, `60` ✓
- Scalar-list: `transform the scores by each plus 5` ([10,20,30]) → `15, 25, 35` ✓
- PEMDAS: `total plus base multiplied by rate` (100, 10, 2) → `120` ✓
- Field access in expr: `price multiplied by quantity` (100×3) → `300` ✓
- `V2_RESERVED` confirmed empty (size 0)

Note: `× 0.9` results display as whole integers (`90`, not `90.0`) per Liminate's `_format_scalar` convention — consistent with `10 divided by 2 → 5` from the arithmetic build. Test expectations match actual interpreter behavior.

## Historical note
This is the **last V2-deferred word**. `choose` (v2d), `when`/`unless` (v3a), `compare` (PR #13), and now `transform` have all been promoted. `V2_RESERVED` is empty — every word designed in the inception checkpoint (May 11, 2026) is now built.

## Test plan
- [x] `pytest tests/` — 1053 pass
- [x] Both grammar modes (record-field, scalar-list)
- [x] `each` pronoun in scalar expressions
- [x] PEMDAS + field access in expressions
- [x] `V2_RESERVED` empty
- [x] Canonical round-trip both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)