### PR TITLE
feat: add `about` declaration — Meta-Structural Era (51 → 52 reserved words)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The sentence is the program.
 
-Liminate is a programming language whose syntax is plain English. A small, bounded vocabulary of 51 reserved words combines into sentences that a real interpreter lexes, parses, type-checks, and runs. Not a prompt. Not a code generator. The prose IS the program.
+Liminate is a programming language whose syntax is plain English. A small, bounded vocabulary of 52 reserved words combines into sentences that a real interpreter lexes, parses, type-checks, and runs. Not a prompt. Not a code generator. The prose IS the program.
 
 ## What it does
 
@@ -67,7 +67,7 @@ pytest tests/
 
 ## How it works
 
-The current build is **v0.4.0**: 19 verbs, 19 connectives, 51 base reserved words, **1053 tests passing**.
+The current build is **v0.5.0**: 19 verbs, 19 connectives, 1 declaration, 52 base reserved words, **1085 tests passing**.
 
 ### The pipeline
 
@@ -78,7 +78,7 @@ Two phases of execution:
 - **Phase 1 — sequential.** Each statement runs in order. Stepwise commit: if a later op fails, earlier side effects remain and the error names what was completed.
 - **Phase 2 — reactive listener.** `when`/`unless` register handlers driven by an external event source (a domain pack adapter). Edge-triggered, depth-first cascading, conservative same-handler-twice cycle detection. `finish` exits immediately and totally.
 
-### The vocabulary (51 words)
+### The vocabulary (52 words)
 
 **Verbs (19):** `remember`, `show`, `filter`, `keep`, `count`, `gather`, `combine`, `each`, `choose`, `finish`, `add`, `remove`, `weakens`, `require`, `assign`, `expect`, `sort`, `compare`, `transform`.
 
@@ -88,6 +88,8 @@ Two phases of execution:
 
 **Articles (3):** `the`, `a`, `an` — decorative; the parser ignores them.
 
+**Declarations (1):** `about` — declares the program's topic as inert metadata. Single, first-line-only; visible to tooling (`inspect`, the build manifest) but never stored or executed. `about "expense authorization"` or `about expense-authorization`.
+
 **Delimiter (1):** `:` — separates a composition name from its body, and a `choose` branch's condition from its action.
 
 `"..."` brackets a multi-word string value or one that would collide with a reserved word. Quotes are value-position only; names use hyphens. Quoted content is preserved verbatim, case included.
@@ -96,7 +98,7 @@ Arithmetic expressions use PEMDAS precedence (multiply/divide before add/subtrac
 
 ### Domain packs
 
-A pack is a small JSON file that adds nouns and verbs while it's loaded. The base 51 words are permanent; pack-contributed words are reserved only when the pack is active.
+A pack is a small JSON file that adds nouns and verbs while it's loaded. The base 52 words are permanent; pack-contributed words are reserved only when the pack is active.
 
 A pack verb declares a slot signature, a type constraint, and one of six execution dispatches:
 
@@ -142,7 +144,7 @@ liminate --pack examples/pack_ui.json --quiet \
 liminate/
 ├── src/liminate/        Pipeline (lexer, reorderer, parser, renderer,
 │                        analyzer, interpreter, listener, adapter, packs/)
-├── tests/               1053 tests
+├── tests/               1085 tests
 ├── examples/            Runnable .limn programs + reference packs
 ├── docs/spec/           Locked specification documents
 └── docs/                Quickstart, syntax tour, pipeline walkthrough
@@ -155,7 +157,7 @@ The locked test sentences are simultaneously test cases and grammar artifacts �
 ### Design principles
 
 - **The prose IS the program.** No inference, no guessing. If the prose doesn't say it, it doesn't happen.
-- **The vocabulary is the boundary.** 51 base reserved words. Expressiveness scales through composition and domain packs, not through adding keywords.
+- **The vocabulary is the boundary.** 52 base reserved words. Expressiveness scales through composition and domain packs, not through adding keywords.
 - **The reorderer does not guess.** Ambiguous arrangements produce an amber clarification prompt rather than a silent pick.
 - **Authorize, don't author.** The on-ramp is modification of a working program, not authorship from a blank file.
 - **The AST is the source of truth.** The parser reconstructs a canonical English sentence so you see what was understood before it runs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liminate"
-version = "0.4.0"
+version = "0.5.0"
 description = "A prose-as-syntax programming language designed from the human end."
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/src/liminate/build.py
+++ b/src/liminate/build.py
@@ -47,7 +47,9 @@ from .parser import (
     RememberCompositionNode,
     SequenceNode,
     WhenNode,
+    _ParseError,
     parse,
+    parse_about,
     parse_when_block,
 )
 from .renderer import render
@@ -86,11 +88,16 @@ class BuildManifest:
     canonical: list[str]
     packs: list[PackManifest]
     vocabulary_in_use: dict[str, list[str]]  # {"verbs": [...], "connectives": [...], "operators": [...]}
+    # Meta-Structural Era: the `about` declaration's topic, or None when
+    # the program has no `about` line. Inert metadata, surfaced by
+    # `--inspect` and the JSON manifest.
+    topic: str | None = None
 
     def as_dict(self) -> dict[str, Any]:
         return {
             "liminate_version": self.liminate_version,
             "source_filename": self.source_filename,
+            "topic": self.topic,
             "source_text": self.source_text,
             "canonical": list(self.canonical),
             "packs": [p.as_summary() for p in self.packs],
@@ -116,7 +123,7 @@ class BuildError(Exception):
         self.message = message
 
 
-def _validate_and_render(source: str) -> tuple[list[str], list[Any]]:
+def _validate_and_render(source: str) -> tuple[list[str], list[Any], str | None]:
     """Run lex → reorder → parse over each top-level statement (and each
     `when` block) and accumulate canonical renderings + parsed ASTs.
 
@@ -126,6 +133,9 @@ def _validate_and_render(source: str) -> tuple[list[str], list[Any]]:
             output preserves paragraph structure).
         asts: the parsed AST for each non-blank statement (used by the
             caller for the Q2 reactive-without-adapter check).
+        topic: the `about` declaration's topic string, or None. Meta-
+            Structural Era — `about` is consumed before the normal
+            pipeline (first-line-only, MS-Q1) and surfaced as metadata.
 
     Raises:
         BuildError on any ERROR_PARSE / ERROR_SEMANTIC / unresolved AMBER
@@ -135,6 +145,8 @@ def _validate_and_render(source: str) -> tuple[list[str], list[Any]]:
     canonical: list[str] = []
     asts: list[Any] = []
     composition_names: set[str] = set()
+    topic: str | None = None
+    first_eligible_seen = False
 
     i = 0
     while i < len(lines):
@@ -144,6 +156,31 @@ def _validate_and_render(source: str) -> tuple[list[str], list[Any]]:
             canonical.append("")
             i += 1
             continue
+
+        # Meta-Structural Era: an `about` declaration is consumed as
+        # metadata before the normal pipeline. It must be the first
+        # eligible (non-blank, non-comment) line and may appear at most
+        # once (MS-Q1).
+        try:
+            decl_tokens = tokenize(line)
+        except LexError as e:
+            raise BuildError(f"line {i + 1}: {e.message}") from None
+        if decl_tokens and decl_tokens[0].type is TokenType.DECLARATION:
+            if first_eligible_seen or topic is not None:
+                raise BuildError(
+                    f"line {i + 1}: 'about' is a declaration that must be "
+                    f"the first line of the program (after any comments). "
+                    f"Only one 'about' declaration is allowed."
+                )
+            try:
+                node = parse_about(decl_tokens)
+            except _ParseError as e:
+                raise BuildError(f"line {i + 1}: {e.message}") from None
+            topic = node.topic
+            first_eligible_seen = True
+            i += 1
+            continue
+        first_eligible_seen = True
 
         try:
             indent = leading_indent(line)
@@ -192,7 +229,7 @@ def _validate_and_render(source: str) -> tuple[list[str], list[Any]]:
         _collect_composition_names(ast, composition_names)
         i += 1
 
-    return canonical, asts
+    return canonical, asts, topic
 
 
 def _parse_line(line: str, comp_names: set[str], *, line_no: int) -> Any:
@@ -538,7 +575,7 @@ def build(
         return 2
 
     try:
-        canonical, asts = _validate_and_render(source_text)
+        canonical, asts, topic = _validate_and_render(source_text)
     except BuildError as e:
         err.write(f"Error: {e.message}\n")
         return 1
@@ -559,6 +596,7 @@ def build(
         canonical=canonical,
         packs=packs,
         vocabulary_in_use=_compute_vocabulary_in_use(source_text),
+        topic=topic,
     )
 
     # Generate entry script + invoke PyInstaller.

--- a/src/liminate/cli.py
+++ b/src/liminate/cli.py
@@ -52,7 +52,7 @@ from .listener import listen
 from .packs.file_watcher import make_file_watcher_pack
 from .packs.stdin import make_stdin_pack
 from .packs.timer import make_timer_pack
-from .parser import parse, parse_when_block
+from .parser import _ParseError, parse, parse_about, parse_when_block
 from .reorderer import reorder
 from .result import LiminateResult, ResultStatus
 from .vocabulary import TokenType
@@ -85,6 +85,11 @@ class Session:
         # Reset by display_result whenever a non-HANDLER_FIRE result is
         # surfaced (so any Phase-1 / shutdown / error line clears it).
         self._last_trigger_key: tuple | None = None
+
+        # Meta-Structural Era: the `about` declaration's topic, set by
+        # run_file when the program's first eligible line is an `about`
+        # declaration. Inert metadata — not stored in the symbol table.
+        self.topic: str | None = None
 
         # v4a §137: pack vocabulary (verbs + nouns) is process-global
         # state. Reset before activating this Session's packs so the
@@ -497,6 +502,11 @@ def run_file(
     write = (out.write if out is not None else lambda s: print(s, end=""))
     lines = content.splitlines()
 
+    # Meta-Structural Era: track whether the first eligible (non-blank,
+    # non-comment) line has been seen, so `about` is recognized only as
+    # the first line and a second `about` anywhere is rejected (MS-Q1).
+    first_eligible_seen = False
+
     i = 0
     while i < len(lines):
         line = lines[i]
@@ -511,6 +521,48 @@ def run_file(
                 write("\n")
             i += 1
             continue
+
+        # Meta-Structural Era: an `about` declaration is consumed before
+        # the normal pipeline. It must be the first eligible line and may
+        # appear at most once. A `DECLARATION` token anywhere else (a
+        # second `about`, or `about` after a normal statement) is an
+        # ERROR_PARSE.
+        try:
+            decl_tokens = tokenize(line)
+        except LexError:
+            decl_tokens = []
+        if decl_tokens and decl_tokens[0].type is TokenType.DECLARATION:
+            if first_eligible_seen or session.topic is not None:
+                err = LiminateResult(
+                    status=ResultStatus.ERROR_PARSE,
+                    message=(
+                        "'about' is a declaration that must be the first "
+                        "line of the program (after any comments). Only one "
+                        "'about' declaration is allowed."
+                    ),
+                    executed=False,
+                )
+            else:
+                try:
+                    node = parse_about(decl_tokens)
+                    session.topic = node.topic
+                    err = None
+                except _ParseError as e:
+                    err = LiminateResult(
+                        status=ResultStatus.ERROR_PARSE,
+                        message=e.message,
+                        executed=False,
+                    )
+            first_eligible_seen = True
+            if err is not None:
+                display_result(
+                    err, session,
+                    auto_confirm_amber=auto_confirm_amber, quiet=quiet, out=out,
+                )
+                session.record_result(err)
+            i += 1
+            continue
+        first_eligible_seen = True
 
         # Tab-in-leading-whitespace is a v3a §110 lex error — surface it
         # as ERROR_PARSE and skip this line.

--- a/src/liminate/inspect_cmd.py
+++ b/src/liminate/inspect_cmd.py
@@ -15,6 +15,7 @@ Format (plain text, primary):
     === Liminate Executable ===
     Version: Liminate <version>
     Source: <source_filename>
+    Topic: <about-topic>          (only when an `about` declaration is present)
 
     --- Source ---
     <verbatim>
@@ -55,6 +56,10 @@ def _format_plain(m: dict[str, Any]) -> str:
     parts.append("=== Liminate Executable ===")
     parts.append(f"Version: Liminate {m.get('liminate_version', '?')}")
     parts.append(f"Source: {m.get('source_filename', '?')}")
+    # Meta-Structural Era: the `about` declaration's topic, when present.
+    topic = m.get("topic")
+    if topic:
+        parts.append(f"Topic: {topic}")
     parts.append("")
     parts.append("--- Source ---")
     parts.append(m.get("source_text", "").rstrip("\n"))

--- a/src/liminate/lexer.py
+++ b/src/liminate/lexer.py
@@ -56,6 +56,7 @@ import re
 from .vocabulary import (
     ARTICLES,
     CONNECTIVES,
+    DECLARATIONS,
     OPERATORS,
     Token,
     TokenType,
@@ -261,6 +262,11 @@ def _classify(cleaned: list[tuple[str, int, bool]]) -> list[Token]:
             tokens.append(Token(TokenType.OPERATOR, word, pos))
         elif word in ARTICLES:
             tokens.append(Token(TokenType.ARTICLE, word, pos))
+        elif word in DECLARATIONS:
+            # Meta-Structural Era: declarations are a new grammatical
+            # category. `about` is handled by the CLI before the normal
+            # parse pipeline (first-line-only, MS-Q1).
+            tokens.append(Token(TokenType.DECLARATION, word, pos))
         elif _NUMBER_RE.match(word):
             tokens.append(Token(TokenType.NUMBER, word, pos))
         else:

--- a/src/liminate/parser.py
+++ b/src/liminate/parser.py
@@ -16,6 +16,10 @@ Sources:
 - v1c §51 (parser lookahead + clause-context tracking)
 - v1d §58 (duplicate `remember` names overwrite — interpreter concern)
 - v1d §60/§61 (record schemas, single-token strings)
+- Meta-Structural Era (`about` declaration): `AboutNode` + `parse_about`,
+  a separate top-level entry point called by the CLI for the first
+  non-blank, non-comment line. `about` is rejected inside the normal
+  `parse()` pipeline (declarations are first-line-only, MS-Q1).
 
 Output:
 - An AST node on success.
@@ -447,6 +451,23 @@ class ExpectNode(ASTNode):
     condition: ASTNode
 
 
+@dataclass
+class AboutNode(ASTNode):
+    """Meta-Structural Era — program topic declaration.
+
+    `about` is a declaration, not a verb. It declares the program's
+    topic as inert metadata: visible to tooling (inspect, Receipts,
+    Inyim, TUI header) but not stored in the symbol table and not
+    executable. Single, first-line-only (MS-Q1).
+
+    `topic` is the declared topic string. For quoted input
+    (`about "expense authorization"`), it is the quoted content.
+    For bare-word input (`about expense authorization`), it is the
+    remaining tokens joined with spaces.
+    """
+    topic: str
+
+
 # Set of operator words that may follow `is` as a comparison introducer.
 _COMPARISON_OPERATORS = frozenset({"above", "below", "equal_to"})
 
@@ -554,6 +575,55 @@ def parse(
         )
 
     return ast
+
+
+# ---------------------------------------------------------------------------
+# Meta-Structural Era: `about` declaration
+# ---------------------------------------------------------------------------
+
+
+def parse_about(tokens: list[Token]) -> AboutNode | None:
+    """Parse an `about` declaration from the first non-blank, non-comment
+    line of a program.
+
+    Returns AboutNode if the line is an `about` declaration, None if it
+    is not (the line should then be fed to the normal parse pipeline).
+    Raises _ParseError (surfaced as ERROR_PARSE by the caller) if the
+    line starts with `about` but has malformed content.
+
+    Design: single, first-line-only (MS-Q1). The CLI calls this on the
+    first eligible line; if it returns an AboutNode, the line is consumed
+    and not passed to the normal pipeline. If it returns None, the line
+    is a normal statement.
+    """
+    if not tokens:
+        return None
+    if not (tokens[0].type is TokenType.DECLARATION and tokens[0].value == "about"):
+        return None
+
+    # `about` with no content is a parse error.
+    if len(tokens) == 1:
+        raise _ParseError(
+            "'about' needs a topic — try: about \"expense authorization\" "
+            "or about expense-authorization."
+        )
+
+    # Quoted string: `about "expense authorization"` — one QUOTED_STRING
+    # token, nothing after it.
+    if tokens[1].type is TokenType.QUOTED_STRING:
+        if len(tokens) > 2:
+            raise _ParseError(
+                f"I didn't expect anything after the quoted topic in "
+                f"'about'. Try: about \"{tokens[1].value}\"."
+            )
+        return AboutNode(topic=tokens[1].value)
+
+    # Bare words: `about expense authorization` — join remaining tokens.
+    # All token types are accepted (UNKNOWN, NUMBER, etc.) and joined
+    # with spaces. Reserved words in this position are allowed — they
+    # are being used as topic words, not as Liminate syntax.
+    words = [t.value for t in tokens[1:]]
+    return AboutNode(topic=" ".join(words))
 
 
 # ---------------------------------------------------------------------------
@@ -781,6 +851,14 @@ def _parse_one_operation(stream: TokenStream, comp: set[str]) -> ASTNode:
             "'unless' is a guard clause that follows a 'when' condition — "
             "it can't introduce a statement on its own. "
             "Try: when <condition> unless <guard>."
+        )
+    # Meta-structural: declarations are first-line-only and handled by
+    # the CLI before the normal pipeline. If `about` reaches here, it
+    # means it appeared on a non-first line.
+    if t.type is TokenType.DECLARATION:
+        raise _ParseError(
+            f"'{t.value}' is a declaration that must be the first line "
+            f"of the program (after any comments). It can't appear here."
         )
     raise _ParseError(f"I didn't expect '{t.value}' at the start of an operation.")
 

--- a/src/liminate/renderer.py
+++ b/src/liminate/renderer.py
@@ -23,6 +23,7 @@ required to round-trip through the parser.
 from __future__ import annotations
 
 from .parser import (
+    AboutNode,
     AddNode,
     ArithmeticNode,
     AssignNode,
@@ -72,6 +73,12 @@ _WHEN_BLOCK_INDENT = "  "
 
 def render(node: ASTNode) -> str:
     """Canonical (paren-free) prose rendering of an AST node."""
+    if isinstance(node, AboutNode):
+        # Meta-Structural Era: quote multi-word topics, leave a single
+        # (e.g. hyphenated) word bare.
+        if " " in node.topic:
+            return f'about "{node.topic}"'
+        return f"about {node.topic}"
     if isinstance(node, NumberLiteral):
         return _fmt_number(node.value)
     if isinstance(node, BareWord):

--- a/src/liminate/vocabulary.py
+++ b/src/liminate/vocabulary.py
@@ -45,6 +45,12 @@ Sources:
   reserved words total) — per-element list mutation via arithmetic
   expressions. V2_RESERVED is now empty; all originally deferred
   words have been promoted.
+- Meta-Structural Era (19 verbs, 19 connectives, 1 declaration, 52
+  reserved words total) — `about` declaration. A declaration is a new
+  grammatical category (TokenType.DECLARATION), distinct from verbs and
+  connectives. `about` declares the program's topic as inert metadata:
+  single, first-line-only (MS-Q1), stored as program-level metadata on
+  the manifest — not in the symbol table, not executable.
 """
 
 from dataclasses import dataclass
@@ -63,6 +69,10 @@ class TokenType(Enum):
     # bypasses vocabulary lookup (§89) and is valid only in value
     # positions per §87.
     QUOTED_STRING = "QUOTED_STRING"
+    # Meta-Structural Era: a declaration is a new grammatical category,
+    # distinct from verbs/connectives/operators. `about` is the first
+    # declaration — it declares the program's topic as inert metadata.
+    DECLARATION = "DECLARATION"
 
 
 @dataclass
@@ -171,8 +181,15 @@ MULTI_WORD_RESERVED: frozenset[str] = frozenset({
     "multiplied", "divided",
 })
 
-# All 51 reserved words. 19 verbs, 19 connectives, 7 operators, 3
-# articles, 0 V2-reserved, 3 multi-word reserved. v3a §124 was 34
+# Meta-structural Era: declarations are a new grammatical category.
+# `about` declares the program's topic as inert metadata — visible to
+# tooling (inspect, Receipts, Inyim) but not to the runtime symbol
+# table. Single, first-line-only (MS-Q1).
+DECLARATIONS: frozenset[str] = frozenset({"about"})
+
+# All 52 reserved words. 19 verbs, 19 connectives, 7 operators, 3
+# articles, 0 V2-reserved, 3 multi-word reserved, 1 declaration.
+# v3a §124 was 34
 # (+1 for `finish`). Liminate `add` verb addendum v1 §9: +1 for `add`
 # (appends an item to a list). `includes` connective + `remove` verb
 # addendum: +2 (list membership test in conditions, retract item from a
@@ -191,8 +208,11 @@ MULTI_WORD_RESERVED: frozenset[str] = frozenset({
 # V2-reserved count fell to 1; the total stays 51. Final V2 promotion:
 # +0 net — `transform` moved from V2_RESERVED to VERBS (verbs 18→19,
 # V2-reserved 1→0); the total stays 51 and V2_RESERVED is now empty.
+# Meta-Structural Era: +1 — `about` declaration (DECLARATIONS), the
+# first member of the new declaration grammatical category. Total 52.
 ALL_RESERVED: frozenset[str] = (
-    VERBS | CONNECTIVES | OPERATORS | ARTICLES | V2_RESERVED | MULTI_WORD_RESERVED
+    VERBS | CONNECTIVES | OPERATORS | ARTICLES | V2_RESERVED
+    | MULTI_WORD_RESERVED | DECLARATIONS
 )
 
 
@@ -219,6 +239,8 @@ def reserved_category(word: str) -> str | None:
         return "article"
     if word in V2_RESERVED:
         return "reserved word"
+    if word in DECLARATIONS:
+        return "declaration"
     if word in _ACTIVE_PACK_VERBS:
         return "verb"
     if word in _ACTIVE_PACK_NOUNS:

--- a/tests/test_about.py
+++ b/tests/test_about.py
@@ -1,0 +1,328 @@
+"""Tests for the `about` declaration — Meta-Structural Era (MS-Q1).
+
+`about` is a declaration (TokenType.DECLARATION), a new grammatical
+category distinct from verbs and connectives. It declares the program's
+topic as inert metadata: single, first-line-only, stored on the manifest
+(not the symbol table) and never executed.
+"""
+
+import io
+import json
+
+import pytest
+
+from liminate.build import BuildManifest, _validate_and_render
+from liminate.cli import Session, run_file
+from liminate.inspect_cmd import format_manifest
+from liminate.lexer import tokenize
+from liminate.parser import AboutNode, _ParseError, parse, parse_about
+from liminate.renderer import render
+from liminate.result import ResultStatus
+from liminate.vocabulary import (
+    ALL_RESERVED,
+    DECLARATIONS,
+    TokenType,
+    reserved_category,
+)
+
+
+# ---------------------------------------------------------------------------
+# Lexer
+# ---------------------------------------------------------------------------
+
+
+def test_about_tokenizes_as_declaration():
+    tokens = tokenize("about")
+    assert len(tokens) == 1
+    assert tokens[0].type is TokenType.DECLARATION
+    assert tokens[0].value == "about"
+
+
+def test_about_full_line_tokenizes_with_trailing_tokens():
+    tokens = tokenize("about expense authorization")
+    assert [(t.type, t.value, t.position) for t in tokens] == [
+        (TokenType.DECLARATION, "about", 0),
+        (TokenType.UNKNOWN, "expense", 6),
+        (TokenType.UNKNOWN, "authorization", 14),
+    ]
+
+
+def test_about_with_quoted_string_tokenizes():
+    tokens = tokenize('about "expense authorization"')
+    assert tokens[0].type is TokenType.DECLARATION
+    assert tokens[1].type is TokenType.QUOTED_STRING
+    assert tokens[1].value == "expense authorization"
+    assert len(tokens) == 2
+
+
+def test_about_is_case_insensitive():
+    # The lexer lowercases words before classification.
+    tokens = tokenize("ABOUT expense")
+    assert tokens[0].type is TokenType.DECLARATION
+    assert tokens[0].value == "about"
+
+
+# ---------------------------------------------------------------------------
+# parse_about
+# ---------------------------------------------------------------------------
+
+
+def test_parse_about_quoted_topic():
+    node = parse_about(tokenize('about "expense authorization"'))
+    assert node == AboutNode(topic="expense authorization")
+
+
+def test_parse_about_bare_word_topic():
+    node = parse_about(tokenize("about expense-authorization"))
+    assert node == AboutNode(topic="expense-authorization")
+
+
+def test_parse_about_multi_word_bare_topic():
+    node = parse_about(tokenize("about expense authorization policy"))
+    assert node == AboutNode(topic="expense authorization policy")
+
+
+def test_parse_about_empty_raises():
+    with pytest.raises(_ParseError):
+        parse_about(tokenize("about"))
+
+
+def test_parse_about_quoted_with_trailing_raises():
+    with pytest.raises(_ParseError):
+        parse_about(tokenize('about "expense" extra'))
+
+
+def test_parse_about_non_about_line_returns_none():
+    assert parse_about(tokenize("remember a string called x with 5")) is None
+
+
+def test_parse_about_empty_token_list_returns_none():
+    assert parse_about([]) is None
+
+
+def test_parse_about_number_in_topic():
+    node = parse_about(tokenize("about version 2"))
+    assert node == AboutNode(topic="version 2")
+
+
+# ---------------------------------------------------------------------------
+# Rejection in the normal parse pipeline
+# ---------------------------------------------------------------------------
+
+
+def test_about_rejected_in_normal_parse_pipeline():
+    result = parse(tokenize("about expense authorization"))
+    assert result.status is ResultStatus.ERROR_PARSE
+    assert "declaration" in result.message
+    assert "first line" in result.message
+
+
+def test_about_as_midprogram_statement_errors():
+    # Reaching _parse_one_operation with a DECLARATION token must error.
+    result = parse(tokenize("about something"))
+    assert result.status is ResultStatus.ERROR_PARSE
+
+
+# ---------------------------------------------------------------------------
+# Vocabulary
+# ---------------------------------------------------------------------------
+
+
+def test_about_in_all_reserved():
+    assert "about" in ALL_RESERVED
+
+
+def test_about_in_declarations():
+    assert DECLARATIONS == frozenset({"about"})
+
+
+def test_reserved_category_about_is_declaration():
+    assert reserved_category("about") == "declaration"
+
+
+def test_all_reserved_count_is_52():
+    assert len(ALL_RESERVED) == 52
+
+
+def test_about_cannot_be_used_as_variable_name():
+    session = Session()
+    result = session.run_line("remember a string called about with 5")
+    assert result.status is ResultStatus.ERROR_PARSE
+    assert "reserved" in result.message
+    assert "declaration" in result.message
+
+
+# ---------------------------------------------------------------------------
+# Renderer
+# ---------------------------------------------------------------------------
+
+
+def test_render_about_quotes_multi_word_topic():
+    assert render(AboutNode(topic="expense authorization")) == (
+        'about "expense authorization"'
+    )
+
+
+def test_render_about_bare_single_word_topic():
+    assert render(AboutNode(topic="expense-authorization")) == (
+        "about expense-authorization"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Integration — run_file
+# ---------------------------------------------------------------------------
+
+
+def _run(tmp_path, source, **kwargs):
+    p = tmp_path / "prog.limn"
+    p.write_text(source, encoding="utf-8")
+    out = io.StringIO()
+    run_file(str(p), out=out, **kwargs)
+    return out.getvalue()
+
+
+def test_program_with_about_first_line_executes(tmp_path):
+    source = (
+        'about "expense authorization"\n'
+        "remember a number called budget with 50000\n"
+        "show budget\n"
+    )
+    output = _run(tmp_path, source, quiet=True)
+    assert "50000" in output
+    # The topic is not stored as a symbol and never shown as data.
+    assert "expense authorization" not in output
+
+
+def test_program_without_about_executes(tmp_path):
+    source = (
+        "remember a number called budget with 50000\n"
+        "show budget\n"
+    )
+    output = _run(tmp_path, source, quiet=True)
+    assert "50000" in output
+
+
+def test_program_with_duplicate_about_errors(tmp_path):
+    source = (
+        'about "first topic"\n'
+        "remember a number called budget with 50000\n"
+        "show budget\n"
+        'about "second topic"\n'
+    )
+    output = _run(tmp_path, source, quiet=True)
+    assert "Error:" in output
+    assert "Only one 'about' declaration is allowed" in output
+
+
+def test_about_after_comment_works(tmp_path):
+    source = (
+        "-- a leading comment\n"
+        "-- another comment\n"
+        'about "expense authorization"\n'
+        "remember a number called budget with 50000\n"
+        "show budget\n"
+    )
+    output = _run(tmp_path, source, quiet=True)
+    assert "50000" in output
+    assert "Error:" not in output
+
+
+def test_about_on_non_first_statement_line_errors(tmp_path):
+    source = (
+        "remember a number called budget with 50000\n"
+        'about "too late"\n'
+    )
+    output = _run(tmp_path, source, quiet=True)
+    assert "Error:" in output
+
+
+def test_topic_not_stored_in_symbol_table(tmp_path):
+    # Invariant §9.4 — the `about` topic is metadata, never a symbol.
+    # Drive run_file end-to-end, then confirm a `show` of the topic
+    # words errors (no symbol of that name exists).
+    source = (
+        'about "expense authorization"\n'
+        "remember a number called budget with 50000\n"
+        "show budget\n"
+        "show expense\n"
+    )
+    output = _run(tmp_path, source, quiet=True)
+    # `budget` resolves; `expense` does not — it was never stored.
+    assert "50000" in output
+    assert "I can't find 'expense'" in output
+
+
+# ---------------------------------------------------------------------------
+# Inspect / manifest
+# ---------------------------------------------------------------------------
+
+
+def _manifest_for(source):
+    canonical, _, topic = _validate_and_render(source)
+    return BuildManifest(
+        liminate_version="0.5.0",
+        source_filename="prog.limn",
+        source_text=source,
+        canonical=canonical,
+        packs=[],
+        vocabulary_in_use={"verbs": [], "connectives": [], "operators": []},
+        topic=topic,
+    ).as_dict()
+
+
+def test_manifest_includes_topic_when_about_present():
+    m = _manifest_for(
+        'about "expense authorization"\n'
+        "remember a number called budget with 50000\n"
+    )
+    assert m["topic"] == "expense authorization"
+    plain = format_manifest(m)
+    assert "Topic: expense authorization" in plain
+    assert json.loads(format_manifest(m, as_json=True))["topic"] == (
+        "expense authorization"
+    )
+
+
+def test_manifest_omits_topic_when_about_absent():
+    m = _manifest_for("remember a number called budget with 50000\n")
+    assert m["topic"] is None
+    plain = format_manifest(m)
+    assert "Topic:" not in plain
+    assert json.loads(format_manifest(m, as_json=True))["topic"] is None
+
+
+def test_build_validate_extracts_topic():
+    canonical, asts, topic = _validate_and_render(
+        'about "expense authorization"\n'
+        "remember a number called budget with 50000\n"
+    )
+    assert topic == "expense authorization"
+    # The `about` line is consumed, not rendered as a statement.
+    assert "remember a number called budget with 50000" in canonical
+
+
+def test_build_validate_duplicate_about_raises():
+    from liminate.build import BuildError
+
+    with pytest.raises(BuildError):
+        _validate_and_render(
+            'about "first"\n'
+            "remember a number called b with 1\n"
+            'about "second"\n'
+        )
+
+
+# ---------------------------------------------------------------------------
+# Failure-mode guard: `about` inside a when action block is rejected
+# ---------------------------------------------------------------------------
+
+
+def test_about_in_when_action_block_errors(tmp_path):
+    source = (
+        "remember a number called level with 100\n"
+        "when level is above 50\n"
+        '  about "nope"\n'
+    )
+    output = _run(tmp_path, source, quiet=True)
+    assert "Error:" in output

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -59,7 +59,7 @@ def test_validate_basic_program():
         "remember a number called age with 30\n"
         "show age\n"
     )
-    canonical, asts = _validate_and_render(source)
+    canonical, asts, _ = _validate_and_render(source)
     assert canonical == [
         "remember a number called age with 30",
         "show age",
@@ -69,7 +69,7 @@ def test_validate_basic_program():
 
 def test_validate_blank_lines_preserved():
     source = "remember a number called age with 30\n\nshow age\n"
-    canonical, _ = _validate_and_render(source)
+    canonical, _, _ = _validate_and_render(source)
     assert canonical == [
         "remember a number called age with 30",
         "",
@@ -89,7 +89,7 @@ def test_validate_when_block():
         "when level is above 50\n"
         "  show level\n"
     )
-    canonical, asts = _validate_and_render(source)
+    canonical, asts, _ = _validate_and_render(source)
     assert _contains_when(asts)
     # The when statement renders multi-line; first line begins with 'when'.
     assert canonical[1].startswith("when ")
@@ -103,7 +103,7 @@ def test_validate_composition_then_call():
         "remember how to bump: remember a number called age with 31\n"
         "bump\n"
     )
-    canonical, asts = _validate_and_render(source)
+    canonical, asts, _ = _validate_and_render(source)
     assert len(asts) == 2
 
 

--- a/tests/test_vocabulary.py
+++ b/tests/test_vocabulary.py
@@ -4,6 +4,7 @@ from liminate.vocabulary import (
     ALL_RESERVED,
     ARTICLES,
     CONNECTIVES,
+    DECLARATIONS,
     DELIMITERS,
     MULTI_WORD_RESERVED,
     OPERATORS,
@@ -77,17 +78,20 @@ def test_multi_word_reserved():
     assert MULTI_WORD_RESERVED == {"equal", "multiplied", "divided"}
 
 
-def test_total_reserved_count_is_51():
-    # 51 reserved words total (unchanged by the final V2 promotion —
-    # `transform` moved category, not in/out of the reserved set).
-    # 19 verbs + 19 connectives + 7 operators + 3 multi-word +
-    # 3 articles + 0 v2-deferred = 51.
-    assert len(ALL_RESERVED) == 51
+def test_total_reserved_count_is_52():
+    # 52 reserved words total. Meta-Structural Era added `about`
+    # (DECLARATIONS, the first declaration). 19 verbs + 19 connectives
+    # + 7 operators + 3 multi-word + 3 articles + 0 v2-deferred +
+    # 1 declaration = 52.
+    assert len(ALL_RESERVED) == 52
 
 
 def test_reserved_sets_are_disjoint():
     # No word should appear in more than one category.
-    sets = [VERBS, CONNECTIVES, OPERATORS, ARTICLES, V2_RESERVED, MULTI_WORD_RESERVED]
+    sets = [
+        VERBS, CONNECTIVES, OPERATORS, ARTICLES, V2_RESERVED,
+        MULTI_WORD_RESERVED, DECLARATIONS,
+    ]
     total = sum(len(s) for s in sets)
     assert total == len(ALL_RESERVED)
 
@@ -105,6 +109,8 @@ def test_reserved_category_for_each_word():
         assert reserved_category(w) == "article"
     for w in V2_RESERVED:
         assert reserved_category(w) == "reserved word"
+    for w in DECLARATIONS:
+        assert reserved_category(w) == "declaration"
 
 
 def test_reserved_category_returns_none_for_unknown():
@@ -186,6 +192,8 @@ def test_token_type_enum_members():
         "DELIMITER", "NUMBER", "UNKNOWN",
         # v2c §86: quoted strings emitted as a single token.
         "QUOTED_STRING",
+        # Meta-Structural Era: `about` and future declarations.
+        "DECLARATION",
     }
 
 


### PR DESCRIPTION
## Summary

Introduces `about`, the first member of a new grammatical category — **declarations** (`TokenType.DECLARATION`), distinct from verbs and connectives. `about` declares the program's topic as **inert metadata**: visible to tooling (`inspect`, the build manifest) but never stored in the symbol table and never executed.

```
about "expense authorization"
about expense-authorization
```

## Design decisions implemented

- **Single, first-line-only (MS-Q1).** One `about` per program, as the first non-blank, non-comment line. A second `about`, or `about` after a statement, is `ERROR_PARSE`.
- **New `DECLARATION` grammatical category.** Not a verb (no `VERB_SIGNATURES` entry), not a connective, not an operator.
- **Program metadata, not symbol table.** The topic lives on `Session.topic` / `BuildManifest.topic`. It never appears in `show` output, can't be filtered/compared.
- **Transparent to tooling.** Rendered by the renderer; surfaced by `inspect` (plain + JSON) and the build manifest. Receipts/Inyim consumption is future work.

## Phases completed (1–6)

| Phase | Files | Change |
|---|---|---|
| 1 | `vocabulary.py`, `lexer.py` | `DECLARATION` token, `DECLARATIONS` frozenset, `ALL_RESERVED` → 52, `reserved_category` → `"declaration"`, lexer classification |
| 2 | `parser.py` | `AboutNode`, `parse_about()` (separate CLI entry point), DECLARATION rejection in `_parse_one_operation` |
| 3 | `renderer.py` | `AboutNode` rendering — quoted multi-word / bare single-word |
| 4 | `inspect_cmd.py`, `build.py` | `Topic:` line + `topic` JSON key; `BuildManifest.topic` |
| 5 | `cli.py` | First-line `about` extraction, duplicate/non-first detection, `Session.topic` |
| 6 | `tests/test_about.py` | 32 new tests |

## Files modified / created

- **Modified:** `vocabulary.py`, `lexer.py`, `parser.py`, `renderer.py`, `inspect_cmd.py`, `build.py`, `cli.py`, `pyproject.toml` (0.4.0 → 0.5.0), `README.md`, `tests/test_vocabulary.py`, `tests/test_build.py`
- **Created:** `tests/test_about.py`

## Invariants satisfied (§9)

1. `len(ALL_RESERVED) == 52`.
2. `about` is `DECLARATION`, not `VERB` — no `VERB_SIGNATURES` entry.
3. First-line-only — consumed by the CLI before the pipeline; rejected if it reaches `_parse_one_operation`.
4. No symbol-table pollution — topic is manifest/session metadata, verified by test.
5. Reserved-word enforcement — `remember a string called about with 5` produces the reserved-word error.

## Tests

`1053 + 32 = 1085 passing`, zero regressions.

## Manual gate

Verified end-to-end on a PyInstaller-built binary: `--inspect` (plain + JSON) and `liminate inspect <binary>` all show `Topic: expense authorization`; running the binary prints `50000` with no topic echo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)