### PR TITLE
feat: promote `within` to a base numeric-tolerance condition operator (#19)

### DIFF
--- a/docs/language/syntax.md
+++ b/docs/language/syntax.md
@@ -210,9 +210,23 @@ flat lists, `each is <operator> <value>`:
 | `is not above`  | less than or equal to (includes the boundary)    |
 | `is not below`  | greater than or equal to (includes the boundary) |
 | `is not equal to` | not equal                                      |
+| `is within N of M` | numeric tolerance: `\|field − M\| ≤ N`          |
+| `includes`      | list membership (`<list> includes <value>`)      |
+| `not includes`  | absence from a list                              |
 
 Note that `not above N` means `≤ N` — the boundary value `N` is
 *kept*, not removed. This is intentional and distinct from `below N`.
+
+`is within N of M` is the numeric-tolerance comparison: it is true when
+the field is within `N` of the target `M` (the boundary is inclusive).
+All three operands must be numbers. `N` may be a literal or a name; `M`
+may be any value expression, including a field access:
+
+```
+require amount is within 5 of target
+keep the readings where each is within 2 of baseline
+choose if amount is within tol of total of order1: show "close enough"
+```
 
 **Compound conditions** use `and` and `or` inside the same `where`:
 

--- a/src/liminate/analyzer.py
+++ b/src/liminate/analyzer.py
@@ -1060,6 +1060,14 @@ def _check_condition(
         _require_numeric(field_type, field_label, cond.op)
         _require_numeric(value_type, value_label, cond.op)
         return
+    if cond.op == "within":
+        # Issue #19: all three operands of `is within <amount> of <target>`
+        # must be numeric.
+        _require_numeric(field_type, field_label, "within")
+        _require_numeric(value_type, value_label, "within")
+        target_type, target_label = _resolve_value(cond.value2, symtab, iterator)
+        _require_numeric(target_type, target_label, "within")
+        return
     if cond.op == "equal_to":
         return  # any same-type comparison; analyzer doesn't enforce
     if cond.op in ("includes", "not_includes"):
@@ -1382,6 +1390,13 @@ def _check_choose_condition(
     if cond.op in ("above", "below"):
         _require_numeric(field_type, field_label, cond.op)
         _require_numeric(value_type, value_label, cond.op)
+        return
+    if cond.op == "within":
+        # Issue #19 — numeric tolerance, also valid in `choose if`.
+        _require_numeric(field_type, field_label, "within")
+        _require_numeric(value_type, value_label, "within")
+        target_type, target_label = _resolve_choose_operand(cond.value2, symtab)
+        _require_numeric(target_type, target_label, "within")
         return
     if cond.op in ("includes", "not_includes"):
         return

--- a/src/liminate/interpreter.py
+++ b/src/liminate/interpreter.py
@@ -219,6 +219,10 @@ def _walk_dependencies(
     if isinstance(node, ConditionNode):
         _walk_dependencies(node.field, seen, ordered)
         _walk_dependencies(node.value, seen, ordered)
+        # Issue #19: the `within` target operand is also a dependency, so a
+        # Phase 2 `when` handler watches the target variable for changes.
+        if node.value2 is not None:
+            _walk_dependencies(node.value2, seen, ordered)
     elif isinstance(node, CompoundConditionNode):
         _walk_dependencies(node.left, seen, ordered)
         _walk_dependencies(node.right, seen, ordered)
@@ -1710,9 +1714,28 @@ def _eval_condition(
         return bool(l) or bool(_eval_condition(cond.right, current_item, symtab))
     if isinstance(cond, ConditionNode):
         field_val = _eval_field(cond.field, current_item, symtab)
+        if cond.op == "within":
+            # Issue #19: |field - target| <= tolerance.
+            tolerance = _eval_value(cond.value, current_item, symtab)
+            target = _eval_value(cond.value2, current_item, symtab)
+            return _within_tolerance(field_val, tolerance, target)
         value_val = _eval_value(cond.value, current_item, symtab)
         return _apply_op(cond.op, field_val, value_val)
     raise _RuntimeError(f"Can't evaluate condition {type(cond).__name__}.")
+
+
+def _within_tolerance(field_val: Any, tolerance: Any, target: Any) -> bool:
+    """Issue #19 — numeric tolerance comparison: True when
+    |field_val - target| <= tolerance. All three operands must be numbers;
+    a non-number produces a friendly runtime error rather than a Python
+    TypeError."""
+    for label, v in (("value", field_val), ("amount", tolerance), ("target", target)):
+        if isinstance(v, bool) or not isinstance(v, (int, float)):
+            raise _RuntimeError(
+                f"'within' compares numbers, but the {label} is "
+                f"{_format_scalar(v)}."
+            )
+    return abs(field_val - target) <= tolerance
 
 
 def _eval_field(field_node: ASTNode, current_item: Any, symtab) -> Any:

--- a/src/liminate/listener.py
+++ b/src/liminate/listener.py
@@ -508,6 +508,18 @@ class _Runner:
             right = self._eval_operand(cond.value)
             if left is _UNSET or right is _UNSET:
                 return False
+            if cond.op == "within":
+                # Issue #19: |field - target| <= tolerance. `value` is the
+                # tolerance, `value2` the target.
+                target = self._eval_operand(cond.value2)
+                if target is _UNSET:
+                    return False
+                if any(
+                    isinstance(v, bool) or not isinstance(v, (int, float))
+                    for v in (left, right, target)
+                ):
+                    return False
+                return abs(left - target) <= right
             return _apply_op(cond.op, left, right)
         return False
 

--- a/src/liminate/parser.py
+++ b/src/liminate/parser.py
@@ -333,8 +333,12 @@ class SequenceNode(ASTNode):
 @dataclass
 class ConditionNode(ASTNode):
     field: ASTNode               # NameRef or EachPronoun
-    op: str                      # is, above, below, equal_to, not_above, not_below, not_equal_to
+    op: str                      # is, above, below, equal_to, not_above, not_below, not_equal_to, within, includes
     value: ASTNode               # NumberLiteral, BareWord, NameRef, EachPronoun
+    # Second right-hand operand, used only by the `within` numeric-tolerance
+    # operator (issue #19): `<field> is within <value> of <value2>` is true
+    # when |field - value2| <= value. None for every other operator.
+    value2: ASTNode | None = None
 
 
 @dataclass
@@ -2435,6 +2439,24 @@ def _parse_simple_condition(stream: TokenStream) -> ConditionNode:
     if nxt is None:
         raise _ParseError("I expected a value or comparison after 'is'.")
 
+    # `is within <amount> of <target>` — numeric tolerance (issue #19):
+    # true when |field - target| <= amount. `within` is a connective, so
+    # it is dispatched here rather than in the OPERATOR branch below.
+    if nxt.type is TokenType.CONNECTIVE and nxt.value == "within":
+        stream.consume()  # eat `within`
+        tolerance = _parse_within_tolerance(stream)
+        of_tok = stream.consume()
+        if not (of_tok and of_tok.type is TokenType.CONNECTIVE and of_tok.value == "of"):
+            got = of_tok.value if of_tok else "end of line"
+            raise _ParseError(
+                f"'within' needs a target — try: "
+                f"<field> is within <amount> of <target>. Got: {got}."
+            )
+        target = _parse_value(stream)
+        return ConditionNode(
+            field=field_node, op="within", value=tolerance, value2=target,
+        )
+
     if nxt.type is TokenType.OPERATOR:
         if nxt.value == "not":
             stream.consume()
@@ -2459,6 +2481,37 @@ def _parse_simple_condition(stream: TokenStream) -> ConditionNode:
     # `is` as equality operator: consume a value.
     value = _parse_value(stream)
     return ConditionNode(field=field_node, op="is", value=value)
+
+
+def _parse_within_tolerance(stream: TokenStream) -> ASTNode:
+    """Parse the tolerance operand of `is within <amount> of <target>`
+    (issue #19) as a single bare atom — a number literal or a name.
+
+    This deliberately does NOT go through `_parse_value`: that would let
+    `_maybe_field_access` swallow the structural `of` (reading the
+    tolerance and target as a single `<name> of <record>` field access),
+    so `within tol of target` would lose its `of`. A name resolves to its
+    numeric value at evaluation time (a `BareWord`, like any other
+    right-hand condition operand)."""
+    tok = stream.consume()
+    if tok is None:
+        raise _ParseError(
+            "'within' needs an amount — try: "
+            "<field> is within <amount> of <target>."
+        )
+    if tok.type is TokenType.NUMBER:
+        return NumberLiteral(value=_parse_number(tok.value))
+    if tok.type is TokenType.UNKNOWN:
+        return BareWord(word=tok.value)
+    cat = reserved_category(tok.value)
+    if cat:
+        raise _ParseError(
+            f"'within' needs a numeric amount, but '{tok.value}' is a "
+            f"{cat} in Liminate."
+        )
+    raise _ParseError(
+        f"'within' needs a numeric amount, not '{tok.value}'."
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/liminate/renderer.py
+++ b/src/liminate/renderer.py
@@ -466,6 +466,9 @@ def _render_condition(node: ConditionNode) -> str:
         return f"{field} is {_OP_WORDS[node.op]} {value}"
     if node.op in _NEGATED_OPS:
         return f"{field} is {_NEGATED_OPS[node.op]} {value}"
+    if node.op == "within":
+        # Issue #19: `<field> is within <amount> of <target>`.
+        return f"{field} is within {value} of {render(node.value2)}"
     if node.op == "includes":
         return f"{field} includes {value}"
     if node.op == "not_includes":

--- a/tests/test_within_operator.py
+++ b/tests/test_within_operator.py
@@ -1,0 +1,204 @@
+"""Tests for the `within` numeric-tolerance condition operator — issue #19.
+
+`<field> is within <amount> of <target>` is true when
+`|field - target| <= amount`. Before this, `within` was a reserved base
+word with no base-language behavior — it only did anything inside the
+session pack's `measure` verb. This promotes it to a real condition
+operator usable everywhere a condition appears: `require`, `expect`,
+`filter`/`keep ... where`, `choose if`, and `when`/`unless`.
+
+The base reserved-word count is unchanged (54) — `within` was already a
+counted connective; it just now means something on its own.
+"""
+
+import io
+
+import pytest
+
+from liminate.cli import Session, run_file
+from liminate.lexer import tokenize
+from liminate.parser import (
+    BareWord,
+    ConditionNode,
+    FieldAccessNode,
+    NumberLiteral,
+    RequireNode,
+    parse,
+)
+from liminate.renderer import render
+from liminate.result import ResultStatus
+from liminate.vocabulary import ALL_RESERVED, reserved_category
+
+
+def _run(tmp_path, src):
+    p = tmp_path / "p.limn"
+    p.write_text(src, encoding="utf-8")
+    out = io.StringIO()
+    run_file(str(p), out=out, quiet=True)
+    return out.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Vocabulary — `within` stays a connective; count unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_within_still_connective_and_count_unchanged():
+    assert reserved_category("within") == "connective"
+    assert "within" in ALL_RESERVED
+    assert len(ALL_RESERVED) == 54
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+
+def test_parse_within_basic():
+    node = parse(tokenize("require amount is within 5 of target"))
+    assert isinstance(node, RequireNode)
+    cond = node.condition
+    assert isinstance(cond, ConditionNode)
+    assert cond.op == "within"
+    assert cond.value == NumberLiteral(5)        # tolerance
+    assert isinstance(cond.value2, BareWord)      # target (name)
+    assert cond.value2.word == "target"
+
+
+def test_parse_within_name_tolerance_and_field_access_target():
+    # The `of` in `within tol of total of o1` must split as
+    # (tolerance=tol)(target=total of o1) — the tolerance must NOT swallow
+    # the structural `of` as a field access.
+    node = parse(tokenize("require amount is within tol of total of o1"))
+    cond = node.condition
+    assert cond.op == "within"
+    assert isinstance(cond.value, BareWord) and cond.value.word == "tol"
+    assert isinstance(cond.value2, FieldAccessNode)
+    assert cond.value2.field == "total"
+    assert cond.value2.record_name == "o1"
+
+
+def test_parse_within_missing_of_errors():
+    result = parse(tokenize("require amount is within 5"))
+    assert result.status is ResultStatus.ERROR_PARSE
+    assert "within" in result.message
+
+
+def test_parse_within_non_numeric_tolerance_errors():
+    result = parse(tokenize('require amount is within "lots" of target'))
+    assert result.status is ResultStatus.ERROR_PARSE
+
+
+# ---------------------------------------------------------------------------
+# Evaluation — boundary is inclusive (<=)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value,expected_pass",
+    [(10, True), (12, True), (8, True), (13, False), (7, False)],  # within 2 of 10
+)
+def test_within_require_boundary(tmp_path, value, expected_pass):
+    src = (
+        f"remember a number called x with {value}\n"
+        "require x is within 2 of 10\n"
+        'show "passed"\n'
+    )
+    out = _run(tmp_path, src)
+    if expected_pass:
+        assert "passed" in out
+        assert "Requirement not met" not in out
+    else:
+        assert "Requirement not met" in out
+
+
+def test_within_in_keep(tmp_path):
+    src = (
+        "remember a list called readings with 9 and 10 and 13 and 20\n"
+        "keep the readings where each is within 2 of 10\n"
+    )
+    out = _run(tmp_path, src)
+    assert out.strip().splitlines()[-1] == "9, 10"
+
+
+def test_within_in_choose(tmp_path):
+    src = (
+        "remember a number called amount with 12\n"
+        'choose if amount is within 5 of 10: show "close" otherwise show "far"\n'
+    )
+    out = _run(tmp_path, src)
+    assert "close" in out and "far" not in out
+
+
+def test_within_name_tolerance_and_field_target_executes(tmp_path):
+    src = (
+        "remember an order called o1 with total as 100\n"
+        "remember a number called amount with 103\n"
+        "remember a number called tol with 5\n"
+        'choose if amount is within tol of total of o1: show "in" otherwise show "out"\n'
+    )
+    out = _run(tmp_path, src)
+    assert "in" in out and "out" not in out
+
+
+# ---------------------------------------------------------------------------
+# Analyzer — operands must be numeric
+# ---------------------------------------------------------------------------
+
+
+def test_within_non_numeric_operand_is_semantic_error():
+    s = Session()
+    s.run_line('remember a string called label with "hi"')
+    s.run_line("remember a number called t with 1")
+    result = s.run_line("require label is within 2 of t")
+    assert result.status is ResultStatus.ERROR_SEMANTIC
+    assert "within" in result.message
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — `when ... within` fires
+# ---------------------------------------------------------------------------
+
+
+def test_within_when_handler_fires(tmp_path):
+    src = (
+        "remember a number called reading with 48\n"
+        "remember a number called target with 50\n"
+        "when reading is within 3 of target\n"
+        '  show "in band"\n'
+        "  finish\n"
+    )
+    out = _run(tmp_path, src)
+    assert "in band" in out
+
+
+# ---------------------------------------------------------------------------
+# Renderer round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        "require amount is within 5 of target",
+        "keep the readings where each is within 2 of 10",
+        "filter the readings where each is within 2 of baseline",
+        "require amount is within tol of total of o1",
+    ],
+)
+def test_within_round_trips(src):
+    node = parse(tokenize(src))
+    assert not hasattr(node, "status"), getattr(node, "message", node)
+    rendered = render(node)
+    assert "is within" in rendered and " of " in rendered
+    assert parse(tokenize(rendered)) == node
+
+
+def test_within_compound_condition(tmp_path):
+    src = (
+        "remember a number called x with 11\n"
+        'require x is within 2 of 10 and x is above 5\n'
+        'show "ok"\n'
+    )
+    out = _run(tmp_path, src)
+    assert "ok" in out and "Requirement not met" not in out


### PR DESCRIPTION
Closes #19.

## Problem

`within` was one of the 54 base reserved words but had **no base-language behavior** — it only did something inside the session pack's `measure` verb:

```
require x is within 5 of y
```
```
Error: The word 'within' is a connective in Liminate and can't be used as a value.
```

So the headline count included a word a user couldn't actually use.

## Resolution — Option A (additive)

`is within <amount> of <target>` is now a real condition operator: true when `|field − target| ≤ amount` (inclusive boundary). It works everywhere a condition appears — `require`, `expect`, `filter`/`keep ... where`, `choose if`, and `when`/`unless`.

**The base reserved-word count is unchanged (54)** — `within` was already a counted connective; it just now means something. So there is **no doc-count propagation** across the repo family (the reason this was chosen over reclassifying it to 53).

## Implementation (full pipeline)

- **parser** — `ConditionNode` gains `value2` (target; used only by `within`). `_parse_simple_condition` dispatches `is within … of …`. `_parse_within_tolerance` parses the tolerance as a bare atom so the structural `of` isn't swallowed by field-access — i.e. `within tol of total of o1` splits as `(tol)(total of o1)`, not `(tol of total) … o1`.
- **interpreter** — `_within_tolerance` with numeric guards; `_walk_dependencies` also walks `value2` so a Phase 2 `when` watches a field-access target.
- **listener** — Phase 2 condition eval handles the three-operand form (with `_UNSET` handling).
- **analyzer** — both condition checkers (`where`/`require` and `choose`) require all three operands numeric.
- **renderer** — `<field> is within <amount> of <target>`; round-trip stable.
- **docs/language/syntax.md** — documents the operator (plus the previously-undocumented `includes`/`not includes` rows).

## Tests

New `tests/test_within_operator.py` (20 cases): parsing incl. the `of` disambiguation, inclusive boundary (`±2 of 10`), `keep`/`choose`/`require`/`when`, name-tolerance + field-access target, non-numeric → semantic error, compound conditions, and render round-trip. Plus a guard that `within` stays a connective and the count stays 54.

`1202 tests pass` (1182 baseline + 20 new), zero regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)