### PR TITLE
feat: --verbose flag for per-line execution metadata

### DIFF
--- a/src/liminate/cli.py
+++ b/src/liminate/cli.py
@@ -13,6 +13,9 @@ Usage:
     liminate <file> --quiet             # Suppress "I understand this as: ..."
                                         # echo; mirror blank source lines so
                                         # visual grouping survives. U1/U4.
+    liminate <file> --verbose           # Emit per-line execution metadata
+                                        # (JSON to stderr). Combinable with
+                                        # --quiet for headless pipeline mode.
     liminate --version                  # Print "Liminate <version>" and exit.
 
 `python -m liminate` is the equivalent module-invocation form and works
@@ -32,6 +35,8 @@ from __future__ import annotations
 
 import json
 import sys
+import time
+from datetime import datetime, timezone
 from importlib.metadata import version as _pkg_version
 from pathlib import Path
 
@@ -476,6 +481,21 @@ def _prompt(message: str) -> str:
         return ""
 
 
+def _emit_verbose_metadata(
+    line_num: int,
+    timestamp: str,
+    duration_ms: float,
+    *,
+    verbose_out=None,
+) -> None:
+    metadata = {
+        "line": line_num,
+        "timestamp": timestamp,
+        "duration_ms": duration_ms,
+    }
+    print(json.dumps(metadata), file=verbose_out or sys.stderr)
+
+
 # ---------------------------------------------------------------------------
 # File + REPL drivers
 # ---------------------------------------------------------------------------
@@ -486,8 +506,10 @@ def run_file(
     *,
     auto_confirm_amber: bool = False,
     quiet: bool = False,
+    verbose: bool = False,
     domain_packs: list[DomainPack] | None = None,
     out=None,
+    verbose_out=None,
 ) -> None:
     """Execute an Liminate source file (Phase 1 + optional Phase 2).
 
@@ -560,6 +582,11 @@ def run_file(
                     auto_confirm_amber=auto_confirm_amber, quiet=quiet, out=out,
                 )
                 session.record_result(err)
+                if verbose:
+                    ts = datetime.now(timezone.utc).isoformat()
+                    _emit_verbose_metadata(
+                        i + 1, ts, 0.0, verbose_out=verbose_out,
+                    )
             i += 1
             continue
         first_eligible_seen = True
@@ -579,6 +606,9 @@ def run_file(
                 auto_confirm_amber=auto_confirm_amber, quiet=quiet, out=out,
             )
             session.record_result(err)
+            if verbose:
+                ts = datetime.now(timezone.utc).isoformat()
+                _emit_verbose_metadata(i + 1, ts, 0.0, verbose_out=verbose_out)
             i += 1
             continue
 
@@ -606,11 +636,19 @@ def run_file(
                 quiet=quiet,
                 out=out,
                 write=write,
+                verbose=verbose,
+                verbose_out=verbose_out,
             )
             continue
 
         # Regular Phase 1 sequential statement.
+        ts = datetime.now(timezone.utc).isoformat()
+        t0 = time.monotonic()
         result = session.run_line(line)
+        dur = round((time.monotonic() - t0) * 1000, 3)
+        if result is not None:
+            result.timestamp = ts
+            result.duration_ms = dur
         display_result(
             result, session,
             auto_confirm_amber=auto_confirm_amber,
@@ -618,6 +656,8 @@ def run_file(
             out=out,
         )
         session.record_result(result)
+        if verbose and result is not None:
+            _emit_verbose_metadata(i + 1, ts, dur, verbose_out=verbose_out)
         i += 1
 
     # v3a §107 — Phase 2 gate: only enter listener mode if Phase 1 had
@@ -664,6 +704,8 @@ def _consume_when_block(
     quiet: bool,
     out,
     write,
+    verbose: bool = False,
+    verbose_out=None,
 ) -> int:
     """Buffer the indented action block starting at line index
     `start_idx + 1` and dispatch the full when-block to the session.
@@ -734,9 +776,20 @@ def _consume_when_block(
             auto_confirm_amber=auto_confirm_amber, quiet=quiet, out=out,
         )
         session.record_result(err)
+        if verbose:
+            ts = datetime.now(timezone.utc).isoformat()
+            _emit_verbose_metadata(
+                start_idx + 1, ts, 0.0, verbose_out=verbose_out,
+            )
         return consumed_through + 1
 
+    ts = datetime.now(timezone.utc).isoformat()
+    t0 = time.monotonic()
     result = session.run_when_block(header_line, action_lines)
+    dur = round((time.monotonic() - t0) * 1000, 3)
+    if result is not None:
+        result.timestamp = ts
+        result.duration_ms = dur
     display_result(
         result, session,
         auto_confirm_amber=auto_confirm_amber,
@@ -744,6 +797,8 @@ def _consume_when_block(
         out=out,
     )
     session.record_result(result)
+    if verbose and result is not None:
+        _emit_verbose_metadata(start_idx + 1, ts, dur, verbose_out=verbose_out)
     return j  # j points to the first un-consumed line
 
 
@@ -964,6 +1019,7 @@ def main(argv: list[str] | None = None) -> int:
 
     auto = False
     quiet = False
+    verbose = False
     pack_paths: list[str] = []
     positional: list[str] = []
     i = 0
@@ -973,6 +1029,8 @@ def main(argv: list[str] | None = None) -> int:
             auto = True
         elif a == "--quiet":
             quiet = True
+        elif a == "--verbose":
+            verbose = True
         elif a == "--version":
             print(f"Liminate {_pkg_version('liminate')}")
             return 0
@@ -1012,6 +1070,7 @@ def main(argv: list[str] | None = None) -> int:
             positional[0],
             auto_confirm_amber=auto,
             quiet=quiet,
+            verbose=verbose,
             domain_packs=domain_packs or None,
         )
     else:

--- a/src/liminate/result.py
+++ b/src/liminate/result.py
@@ -41,6 +41,8 @@ class LiminateResult:
     output: list[str] | None = None
     message: str | None = None
     executed: bool = False
+    timestamp: str | None = None
+    duration_ms: float | None = None
     # `pending_ast` carries the parsed-but-not-executed AST through an amber
     # outcome so the CLI wrapper can resume after user confirmation
     # (v1d §64: two-step flow keeps the core interpreter stateless).

--- a/tests/test_verbose_flag.py
+++ b/tests/test_verbose_flag.py
@@ -1,0 +1,78 @@
+"""Tests for the --verbose CLI flag (v5 §17)."""
+from __future__ import annotations
+
+import io
+import json
+
+from liminate.cli import run_file
+
+
+def test_verbose_emits_metadata_to_stderr(tmp_path):
+    src = tmp_path / "test.limn"
+    src.write_text('remember a string called x with "hello"\nshow x\n')
+
+    stdout_capture = io.StringIO()
+    stderr_capture = io.StringIO()
+
+    run_file(
+        str(src),
+        verbose=True,
+        quiet=True,
+        out=stdout_capture,
+        verbose_out=stderr_capture,
+    )
+
+    metadata = [json.loads(line) for line in stderr_capture.getvalue().splitlines()]
+    assert [m["line"] for m in metadata] == [1, 2]
+    for item in metadata:
+        assert item["timestamp"].endswith("Z") or "+" in item["timestamp"]
+        assert isinstance(item["duration_ms"], (int, float))
+        assert item["duration_ms"] >= 0
+
+
+def test_verbose_off_emits_no_metadata(tmp_path):
+    src = tmp_path / "test.limn"
+    src.write_text('remember a string called x with "hello"\n')
+
+    stdout_capture = io.StringIO()
+    stderr_capture = io.StringIO()
+
+    run_file(
+        str(src),
+        verbose=False,
+        quiet=True,
+        out=stdout_capture,
+        verbose_out=stderr_capture,
+    )
+
+    assert stderr_capture.getvalue() == ""
+    for line in stdout_capture.getvalue().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            json.loads(line)
+            assert False, f"Unexpected JSON in non-verbose output: {line}"
+        except json.JSONDecodeError:
+            pass
+
+
+def test_quiet_verbose_combination(tmp_path):
+    src = tmp_path / "test.limn"
+    src.write_text('remember a string called x with "hello"\n')
+
+    stdout_capture = io.StringIO()
+    stderr_capture = io.StringIO()
+
+    run_file(
+        str(src),
+        verbose=True,
+        quiet=True,
+        out=stdout_capture,
+        verbose_out=stderr_capture,
+    )
+
+    assert "I understand this as:" not in stdout_capture.getvalue()
+    metadata = [json.loads(line) for line in stderr_capture.getvalue().splitlines()]
+    assert len(metadata) == 1
+    assert metadata[0]["line"] == 1


### PR DESCRIPTION
Implements Receipts Checkpoint v5 §17.

What changed:
- Added `--verbose` parsing in `src/liminate/cli.py`.
- Added per-line JSON metadata emission with `line`, `timestamp`, and `duration_ms` to stderr.
- Added a `verbose_out` injection point to make stderr metadata testable without mixing it into stdout.
- Added optional `timestamp` and `duration_ms` fields to `LiminateResult`.
- Added tests for verbose metadata, non-verbose silence, and `--quiet --verbose` behavior.

Validation:
- `pytest tests/test_verbose_flag.py -v`
- `pytest tests/` (rerun with sandbox escalation so PyInstaller could access its user cache; 1211 passed)