### PR TITLE
feat: pack attribution on LiminateResult for pack verb dispatch

### DIFF
--- a/src/liminate/cli.py
+++ b/src/liminate/cli.py
@@ -105,7 +105,9 @@ class Session:
             verbs = pack.verbs()
             nouns = [w for (w, cat) in pack.vocabulary() if cat == "noun"]
             if verbs or nouns:
-                activate_pack_words(verbs=verbs, nouns=nouns)
+                activate_pack_words(
+                    verbs=verbs, nouns=nouns, pack_name=pack.name(),
+                )
 
         # Register declared live values from each pack. Names become
         # visible in the symbol table before Phase 1 begins so `when`
@@ -486,6 +488,7 @@ def _emit_verbose_metadata(
     timestamp: str,
     duration_ms: float,
     *,
+    result: LiminateResult | None = None,
     verbose_out=None,
 ) -> None:
     metadata = {
@@ -493,6 +496,9 @@ def _emit_verbose_metadata(
         "timestamp": timestamp,
         "duration_ms": duration_ms,
     }
+    # Receipts v5 §15 dim. 3 — surface the contributing pack for pack verbs.
+    if result is not None and result.metadata and "pack" in result.metadata:
+        metadata["pack"] = result.metadata["pack"]
     print(json.dumps(metadata), file=verbose_out or sys.stderr)
 
 
@@ -657,7 +663,9 @@ def run_file(
         )
         session.record_result(result)
         if verbose and result is not None:
-            _emit_verbose_metadata(i + 1, ts, dur, verbose_out=verbose_out)
+            _emit_verbose_metadata(
+                i + 1, ts, dur, result=result, verbose_out=verbose_out,
+            )
         i += 1
 
     # v3a §107 — Phase 2 gate: only enter listener mode if Phase 1 had
@@ -798,7 +806,9 @@ def _consume_when_block(
     )
     session.record_result(result)
     if verbose and result is not None:
-        _emit_verbose_metadata(start_idx + 1, ts, dur, verbose_out=verbose_out)
+        _emit_verbose_metadata(
+            start_idx + 1, ts, dur, result=result, verbose_out=verbose_out,
+        )
     return j  # j points to the first un-consumed line
 
 

--- a/src/liminate/interpreter.py
+++ b/src/liminate/interpreter.py
@@ -46,6 +46,7 @@ from .vocabulary import (
     SetFieldExecution,
     SetValueExecution,
     SubstringCheckExecution,
+    get_pack_verb_owner,
 )
 
 
@@ -396,12 +397,21 @@ def _execute_single(
             executed=False,
         )
     _mark_live_value_active_if_remember(node, live_value_registry)
-    return LiminateResult(
+    result = LiminateResult(
         status=ResultStatus.SUCCESS,
         canonical=render(node),
         output=output if output else None,
         executed=True,
     )
+    # Receipts v5 §15 dim. 3 — attribute pack-verb results to the pack
+    # that contributed the verb. Base verbs leave the key absent.
+    if isinstance(node, PackVerbNode):
+        owner = get_pack_verb_owner(node.word)
+        if owner is not None:
+            if result.metadata is None:
+                result.metadata = {}
+            result.metadata["pack"] = owner
+    return result
 
 
 def _execute_sequence(

--- a/src/liminate/vocabulary.py
+++ b/src/liminate/vocabulary.py
@@ -383,10 +383,21 @@ class PackVerbSignature:
 _ACTIVE_PACK_VERBS: dict[str, PackVerbSignature] = {}
 _ACTIVE_PACK_NOUNS: set[str] = set()
 
+# Receipts v5 §15 dim. 3 — verb word -> contributing pack name. Populated
+# alongside _ACTIVE_PACK_VERBS so the interpreter can attribute a pack verb
+# result to the pack that defined it. PackVerbSignature is frozen, so the
+# attribution lives here rather than on the signature.
+_ACTIVE_PACK_VERB_OWNERS: dict[str, str] = {}
+
 
 def get_active_pack_verb(word: str) -> PackVerbSignature | None:
     """Return the signature for `word` if it's an active pack verb."""
     return _ACTIVE_PACK_VERBS.get(word)
+
+
+def get_pack_verb_owner(word: str) -> str | None:
+    """Return the name of the pack that contributed `word`, if any."""
+    return _ACTIVE_PACK_VERB_OWNERS.get(word)
 
 
 def active_pack_verb_words() -> frozenset[str]:
@@ -400,14 +411,21 @@ def active_pack_nouns() -> frozenset[str]:
 def activate_pack_words(
     verbs: list[PackVerbSignature] | None = None,
     nouns: list[str] | None = None,
+    pack_name: str | None = None,
 ) -> None:
     """Add the given pack verbs and nouns to the active vocabulary
     (v4a §137 / v1a §29). Each pack contributes additively; the caller
     decides when to reset via `deactivate_all_pack_words`. Duplicate
     pack verb registrations (same word) overwrite — packs are vetted
-    by the Session, not by this table."""
+    by the Session, not by this table.
+
+    `pack_name` records which pack contributed each verb so the
+    interpreter can attribute results (Receipts v5 §15 dim. 3). When
+    omitted, verbs activate without an owner and carry no attribution."""
     for sig in verbs or ():
         _ACTIVE_PACK_VERBS[sig.word] = sig
+        if pack_name is not None:
+            _ACTIVE_PACK_VERB_OWNERS[sig.word] = pack_name
     for word in nouns or ():
         _ACTIVE_PACK_NOUNS.add(word)
 
@@ -418,6 +436,7 @@ def deactivate_all_pack_words() -> None:
     the current Session's pack list."""
     _ACTIVE_PACK_VERBS.clear()
     _ACTIVE_PACK_NOUNS.clear()
+    _ACTIVE_PACK_VERB_OWNERS.clear()
 
 
 # Verb signatures (inception §17, refined by v1b/v1c/v1d). Each verb maps

--- a/tests/test_pack_attribution.py
+++ b/tests/test_pack_attribution.py
@@ -1,0 +1,75 @@
+"""Tests for pack attribution on LiminateResult metadata.
+
+Receipts Checkpoint v5 §15 dimension 3: when a pack verb resolves a line,
+the result carries `metadata["pack"]` naming the pack that contributed the
+verb. Base-vocabulary verbs leave the key absent — its absence means
+"base vocabulary."
+
+The session pack ships in examples/pack_session.json (name "session",
+verbs cite/verify/measure). The tests load it through the same
+TestDomainPack path the other pack integration tests use, then drive a
+Session so the full parse → execute path runs.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from liminate.adapter import TestDomainPack, parse_pack_verb_signature
+from liminate.cli import Session
+
+
+def _load_session_pack() -> TestDomainPack:
+    path = (
+        Path(__file__).resolve().parent.parent
+        / "examples"
+        / "pack_session.json"
+    )
+    config = json.loads(path.read_text(encoding="utf-8"))
+    vocab = [
+        (e["word"], e.get("category", "noun"))
+        for e in config.get("vocabulary", [])
+    ]
+    verbs = [parse_pack_verb_signature(v) for v in config.get("verbs", [])]
+    return TestDomainPack(
+        declarations=[],
+        script=[],
+        name=config.get("name", "session"),
+        vocabulary=vocab,
+        verbs=verbs,
+    )
+
+
+def test_pack_verb_carries_pack_name():
+    """A pack verb result has metadata['pack'] set to the pack name."""
+    pack = _load_session_pack()
+    session = Session(domain_packs=[pack])
+
+    session.run_line('remember a source called s with "hello world"')
+    result = session.run_line('cite "hello" from s')
+
+    assert result is not None
+    assert result.metadata is not None
+    assert result.metadata.get("pack") == pack.name()
+
+
+def test_base_verb_has_no_pack_attribution():
+    """A base verb result does NOT carry metadata['pack']."""
+    pack = _load_session_pack()
+    session = Session(domain_packs=[pack])
+
+    result = session.run_line('remember a string called x with "test"')
+
+    assert result is not None
+    if result.metadata is not None:
+        assert "pack" not in result.metadata
+
+
+def test_base_verb_no_pack_loaded():
+    """Without any pack, base verbs still carry no pack attribution."""
+    session = Session()
+    result = session.run_line('remember a string called x with "test"')
+
+    assert result is not None
+    if result.metadata is not None:
+        assert "pack" not in result.metadata


### PR DESCRIPTION
Implements Receipts Checkpoint v5 §15 dimension 3.

Pack verb results now carry `metadata["pack"]` with the name of the pack that contributed the verb. Base vocabulary verbs leave the key absent — its absence means "base vocabulary."

## Changes
- `vocabulary.py` — verb→pack-name ownership map (`_ACTIVE_PACK_VERB_OWNERS`), populated at activation via a new `pack_name` arg to `activate_pack_words`. `PackVerbSignature` is frozen, so attribution lives beside the signature table rather than on the signature.
- `interpreter.py` — `_execute_single` attaches `metadata["pack"]` when the node is a `PackVerbNode` with a known owner.
- `cli.py` — `--verbose` per-line JSON gains a `"pack"` key for pack verb lines.
- `tests/test_pack_attribution.py` — covers pack-verb attribution, base-verb absence (with and without a pack loaded).

## Verification
- `pytest tests/` — 1214 passed.
- `liminate <file> --verbose --pack examples/pack_session.json` confirms `cite` lines carry `"pack": "session"` while base verbs do not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)