### PR TITLE
feat: add forbid verb — deontic prohibition (inverted require)

### DIFF
--- a/src/liminate/analyzer.py
+++ b/src/liminate/analyzer.py
@@ -78,6 +78,7 @@ from .parser import (
     RememberRecordNode,
     RememberValueNode,
     RequireNode,
+    ForbidNode,
     SequenceNode,
     ShowNode,
     SortNode,
@@ -322,6 +323,11 @@ def _check(
         # validation path as `choose if`: no iterator, names resolve
         # against the symbol table directly, field access uses `of`.
         _check_choose_condition(node.condition, symtab)
+    elif isinstance(node, ForbidNode):
+        # Deontic Era — same condition validation as `require`.
+        # Behavior differs only at runtime (halts on true instead
+        # of false).
+        _check_choose_condition(node.condition, symtab)
     elif isinstance(node, ExpectNode):
         # Epistemic Era batch 3 — same condition validation as `require`.
         # Behavior differs only at runtime (divergence emits output;
@@ -503,6 +509,10 @@ def _side_effect_verb(
         # Normative Era batch 2 — `require` either passes silently or
         # halts with REQUIREMENT_NOT_MET. Never produces a value.
         return "require"
+    if isinstance(node, ForbidNode):
+        # Deontic Era — `forbid` halts on true or passes silently.
+        # Never produces a value.
+        return "forbid"
     if isinstance(node, ExpectNode):
         # Epistemic Era batch 3 — `expect` is silent on pass; emits
         # divergence output on failure. Never produces a value.

--- a/src/liminate/interpreter.py
+++ b/src/liminate/interpreter.py
@@ -93,6 +93,7 @@ from .parser import (
     RememberRecordNode,
     RememberValueNode,
     RequireNode,
+    ForbidNode,
     SequenceNode,
     ShowNode,
     SortNode,
@@ -360,6 +361,15 @@ class _RequirementNotMet(Exception):
         self.message = message
 
 
+class _ProhibitionViolated(Exception):
+    """Deontic Era — raised when a `forbid` condition evaluates true.
+    Surfaced to callers as PROHIBITION_VIOLATED. Same unwind semantics
+    as _RequirementNotMet: stepwise operations stay committed."""
+    def __init__(self, message: str):
+        super().__init__(message)
+        self.message = message
+
+
 def _execute_single(
     node: ASTNode,
     symtab: dict[str, SymbolEntry],
@@ -392,6 +402,13 @@ def _execute_single(
     except _RequirementNotMet as e:
         return LiminateResult(
             status=ResultStatus.REQUIREMENT_NOT_MET,
+            canonical=render(node),
+            message=e.message,
+            executed=False,
+        )
+    except _ProhibitionViolated as e:
+        return LiminateResult(
+            status=ResultStatus.PROHIBITION_VIOLATED,
             canonical=render(node),
             message=e.message,
             executed=False,
@@ -448,6 +465,17 @@ def _execute_sequence(
                 op,
                 LiminateResult(
                     status=ResultStatus.REQUIREMENT_NOT_MET,
+                    message=e.message,
+                ),
+                completed_canonicals,
+                outputs,
+                seq,
+            )
+        except _ProhibitionViolated as e:
+            return _stepwise_error(
+                op,
+                LiminateResult(
+                    status=ResultStatus.PROHIBITION_VIOLATED,
                     message=e.message,
                 ),
                 completed_canonicals,
@@ -577,6 +605,8 @@ def _exec_op(
         return _exec_weakens(node, symtab)
     if isinstance(node, RequireNode):
         return _exec_require(node, symtab, current_item)
+    if isinstance(node, ForbidNode):
+        return _exec_forbid(node, symtab, current_item)
     if isinstance(node, ExpectNode):
         return _exec_expect(node, symtab, current_item)
     if isinstance(node, AssignNode):
@@ -1347,6 +1377,26 @@ def _exec_require(
     if actual:
         msg += f" {actual}"
     raise _RequirementNotMet(msg)
+
+
+def _exec_forbid(
+    node: ForbidNode,
+    symtab: dict[str, SymbolEntry],
+    current_item: Any,
+) -> list[str]:
+    """Deontic Era — evaluate the condition. Silent on false (no
+    prohibition triggered); raises _ProhibitionViolated on true.
+    The error message echoes the condition in canonical form and
+    reports the actual value(s) that triggered the prohibition.
+    """
+    if not _eval_condition(node.condition, current_item, symtab):
+        return []
+    condition_text = render(node.condition)
+    actual = _condition_actual_values(node.condition, current_item, symtab)
+    msg = f"Prohibition violated: {condition_text}."
+    if actual:
+        msg += f" {actual}"
+    raise _ProhibitionViolated(msg)
 
 
 def _exec_expect(

--- a/src/liminate/parser.py
+++ b/src/liminate/parser.py
@@ -523,6 +523,21 @@ class RequireNode(ASTNode):
 
 
 @dataclass
+class ForbidNode(ASTNode):
+    """Deontic Era — prohibition verb.
+
+    Evaluates `condition`; if true, execution halts with
+    PROHIBITION_VIOLATED. If false, silent pass. Same condition AST
+    as `require` / `choose if` / `where`. Mirrors `require` with
+    inverted polarity.
+    """
+    condition: ASTNode
+    rationale: str | None = field(default=None, compare=False)
+    inherited: bool = field(default=False, compare=False)
+    inherited_from: str | None = field(default=None, compare=False)
+
+
+@dataclass
 class AssignNode(ASTNode):
     """Delegated Era batch 3 — assignment/delegation verb.
 
@@ -1226,6 +1241,8 @@ def _parse_verb_statement(stream: TokenStream, comp: set[str]) -> ASTNode:
         return _parse_weakens(stream)
     if verb.value == "require":
         return _parse_require(stream)
+    if verb.value == "forbid":
+        return _parse_forbid(stream)
     if verb.value == "assign":
         return _parse_assign(stream)
     if verb.value == "expect":
@@ -1884,6 +1901,31 @@ def _parse_require(stream: TokenStream) -> RequireNode:
     finally:
         stream.pop_clause()
     return RequireNode(condition=condition)
+
+
+# ---------------------------------------------------------------------------
+# forbid (Deontic Era)
+# ---------------------------------------------------------------------------
+
+
+def _parse_forbid(stream: TokenStream) -> ForbidNode:
+    """`forbid <condition>` — prohibition verb.
+
+    Same condition grammar as `require`. The difference is purely
+    in runtime behavior: `require` halts on false, `forbid` halts
+    on true.
+    """
+    if stream.at_end():
+        raise _ParseError(
+            "'forbid' needs a condition — try: "
+            "forbid <field> is <operator> <value>."
+        )
+    stream.push_clause("forbid")
+    try:
+        condition = _parse_or_condition(stream)
+    finally:
+        stream.pop_clause()
+    return ForbidNode(condition=condition)
 
 
 # ---------------------------------------------------------------------------
@@ -2797,6 +2839,10 @@ def _contains_mixed_precedence(node: ASTNode) -> bool:
     if isinstance(node, RequireNode):
         # Normative Era batch 2: `require` conditions follow the same
         # mixed-precedence rule as `where` / `choose if` clauses (v1a §30).
+        return _condition_is_mixed(node.condition)
+    if isinstance(node, ForbidNode):
+        # Deontic Era: `forbid` conditions follow the same
+        # mixed-precedence rule as `require` / `where`.
         return _condition_is_mixed(node.condition)
     if isinstance(node, ExpectNode):
         # Epistemic Era batch 3: `expect` conditions follow the same

--- a/src/liminate/renderer.py
+++ b/src/liminate/renderer.py
@@ -55,6 +55,7 @@ from .parser import (
     RememberRecordNode,
     RememberValueNode,
     RequireNode,
+    ForbidNode,
     SequenceNode,
     ShowNode,
     SortNode,
@@ -243,6 +244,9 @@ def _render_node(node: ASTNode) -> str:
     if isinstance(node, RequireNode):
         # Normative Era batch 2 — `require <condition>`.
         return f"require {render(node.condition)}"
+    if isinstance(node, ForbidNode):
+        # Deontic Era — `forbid <condition>`.
+        return f"forbid {render(node.condition)}"
     if isinstance(node, ExpectNode):
         # Epistemic Era batch 3 — `expect <condition>`.
         return f"expect {render(node.condition)}"
@@ -328,6 +332,8 @@ def render_with_explicit_precedence(node: ASTNode) -> str:
         return _render_sequence(node, render_with_explicit_precedence)
     if isinstance(node, RequireNode):
         return f"require {render_with_explicit_precedence(node.condition)}"
+    if isinstance(node, ForbidNode):
+        return f"forbid {render_with_explicit_precedence(node.condition)}"
     if isinstance(node, ExpectNode):
         return f"expect {render_with_explicit_precedence(node.condition)}"
     if isinstance(node, AssignNode):

--- a/src/liminate/result.py
+++ b/src/liminate/result.py
@@ -32,6 +32,11 @@ class ResultStatus(Enum):
     # runtime. Distinct from ERROR_SEMANTIC ("the program has a bug")
     # — REQUIREMENT_NOT_MET means "the data violates a rule."
     REQUIREMENT_NOT_MET = "requirement_not_met"
+    # Deontic Era: a `forbid` condition evaluated true at runtime.
+    # Distinct from REQUIREMENT_NOT_MET — PROHIBITION_VIOLATED means
+    # "the data triggers a prohibition." The deontic triple:
+    # require (obligation), forbid (prohibition), permit (permission).
+    PROHIBITION_VIOLATED = "prohibition_violated"
 
 
 @dataclass

--- a/src/liminate/vocabulary.py
+++ b/src/liminate/vocabulary.py
@@ -57,6 +57,8 @@ Sources:
   node. Per-statement only (MS-Q2): statement-terminal, consumed after
   all verb slots are filled. Visible to rendering, inspect, and Receipts;
   not executable, not in the symbol table.
+- Deontic Era (20 verbs, 20 connectives, 55 reserved words total)
+  — `forbid` verb (prohibition, inverted `require`).
 - Meta-Structural Era batch 3 (19 verbs, 20 connectives, 8 operators, 1
   declaration, 54 reserved words total) — `inherited` operator. A
   statement-initial modifier marking a verb statement as carried forward
@@ -110,6 +112,11 @@ VERBS: frozenset[str] = frozenset({
     # Normative Era batch 2: `require` evaluates a condition and halts
     # with REQUIREMENT_NOT_MET if false; silent on success.
     "require",
+    # Deontic Era: `forbid` evaluates a condition and halts with
+    # PROHIBITION_VIOLATED if true; silent on false. Mirrors `require`
+    # with inverted polarity — `require` halts when false, `forbid`
+    # halts when true.
+    "forbid",
     # Delegated Era batch 3: `assign <item> to <recipient>` stores an
     # item-to-recipient mapping in the symbol table.
     "assign",
@@ -214,7 +221,7 @@ MULTI_WORD_RESERVED: frozenset[str] = frozenset({
 # table. Single, first-line-only (MS-Q1).
 DECLARATIONS: frozenset[str] = frozenset({"about"})
 
-# All 54 reserved words. 19 verbs, 20 connectives, 8 operators, 3
+# All 55 reserved words. 20 verbs, 20 connectives, 8 operators, 3
 # articles, 0 V2-reserved, 3 multi-word reserved, 1 declaration.
 # v3a §124 was 34
 # (+1 for `finish`). Liminate `add` verb addendum v1 §9: +1 for `add`
@@ -242,6 +249,8 @@ DECLARATIONS: frozenset[str] = frozenset({"about"})
 # Meta-Structural Era batch 3: +1 — `inherited` operator (statement-
 # initial provenance modifier). `from` attribution reuses the existing
 # `from` connective (MS-Q4), so no new word. Total 54.
+# Deontic Era: +1 — `forbid` verb (prohibition, inverted `require`).
+# Total 55.
 ALL_RESERVED: frozenset[str] = (
     VERBS | CONNECTIVES | OPERATORS | ARTICLES | V2_RESERVED
     | MULTI_WORD_RESERVED | DECLARATIONS
@@ -258,7 +267,7 @@ def reserved_category(word: str) -> str | None:
     v4a §137: active pack verbs report as "verb"; active pack nouns
     report as "noun". Pack words are only reserved while the pack that
     declared them is loaded — the base vocabulary is the canonical
-    surface (currently 51 reserved words — 19 verbs, 0 V2-reserved;
+    surface (currently 55 reserved words — 20 verbs, 0 V2-reserved;
     see module docstring).
     """
     if word in VERBS:
@@ -469,6 +478,9 @@ VERB_SIGNATURES: dict[str, list[str]] = {
     # Normative Era batch 2: `require <condition>`. Same condition
     # grammar as `choose if` / `where`.
     "require":  ["condition"],
+    # Deontic Era: `forbid <condition>`. Same condition grammar as
+    # `require` / `choose if` / `where`.
+    "forbid":   ["condition"],
     # Delegated Era batch 3: `assign <item> to <recipient>`.
     "assign":   ["item", "recipient"],
     # Epistemic Era batch 3: `expect <condition>`. Same condition

--- a/tests/test_about.py
+++ b/tests/test_about.py
@@ -140,9 +140,10 @@ def test_reserved_category_about_is_declaration():
     assert reserved_category("about") == "declaration"
 
 
-def test_all_reserved_count_is_54():
+def test_all_reserved_count_is_55():
     # Meta-Structural Era batch 3 added the `inherited` operator (53 → 54).
-    assert len(ALL_RESERVED) == 54
+    # Deontic Era added the `forbid` verb (54 → 55).
+    assert len(ALL_RESERVED) == 55
 
 
 def test_about_cannot_be_used_as_variable_name():

--- a/tests/test_because.py
+++ b/tests/test_because.py
@@ -81,8 +81,9 @@ def test_reserved_category_because_is_connective():
     assert reserved_category("because") == "connective"
 
 
-def test_all_reserved_count_is_54():
-    assert len(ALL_RESERVED) == 54
+def test_all_reserved_count_is_55():
+    # Deontic Era added the `forbid` verb (54 → 55).
+    assert len(ALL_RESERVED) == 55
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_forbid.py
+++ b/tests/test_forbid.py
@@ -1,0 +1,300 @@
+"""Deontic Era — tests for the `forbid` verb.
+
+`forbid` mirrors `require` with inverted polarity: it evaluates a
+condition and halts with PROHIBITION_VIOLATED if the condition is true;
+silent pass if false. Covers parsing, analysis (including mixed and/or
+amber and void-return detection), execution (silent pass, violation with
+actual values reported), stepwise semantics, round-trip rendering, and
+vocabulary registration.
+"""
+
+from __future__ import annotations
+
+from liminate.analyzer import _side_effect_verb
+from liminate.cli import Session
+from liminate.lexer import tokenize
+from liminate.parser import (
+    CompoundConditionNode,
+    ConditionNode,
+    ForbidNode,
+    parse,
+)
+from liminate.renderer import render
+from liminate.reorderer import reorder
+from liminate.result import LiminateResult, ResultStatus
+from liminate.vocabulary import VERBS, reserved_category
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse(line: str):
+    toks = tokenize(line)
+    reordered = reorder(toks)
+    if isinstance(reordered, LiminateResult):
+        return reordered
+    return parse(reordered)
+
+
+def _session() -> Session:
+    return Session()
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+
+def test_parses_basic_forbid():
+    ast = _parse("forbid total is above 10000")
+    assert isinstance(ast, ForbidNode)
+    assert isinstance(ast.condition, ConditionNode)
+    assert ast.condition.op == "above"
+
+
+def test_parses_forbid_compound_and():
+    ast = _parse("forbid total is above 10000 and quantity is above 50")
+    assert isinstance(ast, ForbidNode)
+    assert isinstance(ast.condition, CompoundConditionNode)
+    assert ast.condition.connector == "and"
+
+
+def test_parses_forbid_compound_or():
+    ast = _parse("forbid total is above 10000 or quantity is above 50")
+    assert isinstance(ast, ForbidNode)
+    assert isinstance(ast.condition, CompoundConditionNode)
+    assert ast.condition.connector == "or"
+
+
+def test_mixed_and_or_triggers_amber():
+    r = _parse(
+        "forbid x is above 1 and y is below 5 or z is above 7"
+    )
+    assert isinstance(r, LiminateResult)
+    assert r.status is ResultStatus.AMBER_PRECEDENCE
+
+
+def test_parses_forbid_negated():
+    ast = _parse("forbid total is not above 100")
+    assert isinstance(ast, ForbidNode)
+    assert ast.condition.op == "not_above"
+
+
+def test_parses_forbid_with_includes():
+    ast = _parse('forbid categories includes "restricted"')
+    assert isinstance(ast, ForbidNode)
+    assert ast.condition.op == "includes"
+
+
+def test_parses_forbid_with_within():
+    ast = _parse("forbid price is within 5 of target-price")
+    assert isinstance(ast, ForbidNode)
+    assert ast.condition.op == "within"
+
+
+def test_parses_forbid_field_access():
+    ast = _parse("forbid total of order is above 10000")
+    assert isinstance(ast, ForbidNode)
+
+
+def test_parse_error_when_no_condition():
+    r = _parse("forbid")
+    assert isinstance(r, LiminateResult)
+    assert r.status is ResultStatus.ERROR_PARSE
+    assert "needs a condition" in (r.message or "")
+
+
+def test_because_attaches_rationale():
+    ast = _parse('forbid total is above 10000 because "regulatory cap"')
+    assert isinstance(ast, ForbidNode)
+    assert ast.rationale == "regulatory cap"
+
+
+def test_inherited_modifier():
+    ast = _parse("inherited forbid total is above 10000")
+    assert isinstance(ast, ForbidNode)
+    assert ast.inherited is True
+
+
+def test_full_canonical_metadata_order():
+    ast = _parse(
+        'inherited forbid total is above 10000 '
+        'because "regulatory cap" from agent-compliance'
+    )
+    assert isinstance(ast, ForbidNode)
+    assert ast.inherited is True
+    assert ast.rationale == "regulatory cap"
+    assert ast.inherited_from == "agent-compliance"
+
+
+# ---------------------------------------------------------------------------
+# Analyzer errors (semantic vs prohibition)
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_variable_is_semantic_error():
+    s = _session()
+    r = s.run_line("forbid nonexistent is above 5")
+    assert r.status is ResultStatus.ERROR_SEMANTIC
+    assert "can't find" in (r.message or "")
+
+
+def test_numeric_operator_on_text_is_semantic_error():
+    s = _session()
+    s.run_line('remember a value called label with "hello"')
+    r = s.run_line("forbid label is above 5")
+    assert r.status is ResultStatus.ERROR_SEMANTIC
+
+
+def test_forbid_is_void_return_verb():
+    ast = _parse("forbid total is above 10000")
+    assert _side_effect_verb(ast, {}, set()) == "forbid"
+
+
+# ---------------------------------------------------------------------------
+# Execution
+# ---------------------------------------------------------------------------
+
+
+def test_forbid_passes_silently_when_false():
+    s = _session()
+    s.run_line("remember a value called total with 50")
+    r = s.run_line("forbid total is above 100")
+    assert r.status is ResultStatus.SUCCESS
+    assert r.output is None
+
+
+def test_forbid_violates_when_true():
+    s = _session()
+    s.run_line("remember a value called total with 150")
+    r = s.run_line("forbid total is above 100")
+    assert r.status is ResultStatus.PROHIBITION_VIOLATED
+    assert "Prohibition violated" in (r.message or "")
+
+
+def test_forbid_reports_actual_value():
+    s = _session()
+    s.run_line("remember a value called total with 15000")
+    r = s.run_line("forbid total is above 10000")
+    assert r.status is ResultStatus.PROHIBITION_VIOLATED
+    assert "total is above 10000" in (r.message or "")
+    assert "total is 15000" in (r.message or "")
+
+
+def test_forbid_compound_true_violates():
+    s = _session()
+    s.run_line("remember a value called total with 20000")
+    s.run_line("remember a value called quantity with 80")
+    r = s.run_line(
+        "forbid total is above 10000 and quantity is above 50"
+    )
+    assert r.status is ResultStatus.PROHIBITION_VIOLATED
+
+
+def test_forbid_compound_false_passes():
+    s = _session()
+    s.run_line("remember a value called total with 20000")
+    s.run_line("remember a value called quantity with 10")
+    r = s.run_line(
+        "forbid total is above 10000 and quantity is above 50"
+    )
+    assert r.status is ResultStatus.SUCCESS
+
+
+def test_forbid_includes_violates():
+    s = _session()
+    s.run_line('remember a list called categories with "restricted"')
+    r = s.run_line('forbid categories includes "restricted"')
+    assert r.status is ResultStatus.PROHIBITION_VIOLATED
+
+
+def test_forbid_inside_choose_branch():
+    s = _session()
+    s.run_line('remember a value called role with "guest"')
+    s.run_line("remember a value called clearance with 9")
+    r = s.run_line(
+        'choose if role is "guest": forbid clearance is above 3'
+    )
+    assert r.status is ResultStatus.PROHIBITION_VIOLATED
+
+
+# ---------------------------------------------------------------------------
+# Stepwise semantics
+# ---------------------------------------------------------------------------
+
+
+def test_stepwise_commit_before_violated_forbid_with_and():
+    s = _session()
+    s.run_line('remember a list called audit-log with "none"')
+    s.run_line("remember a value called total with 15000")
+    r = s.run_line(
+        'add "received" to audit-log and forbid total is above 10000'
+    )
+    assert r.status is ResultStatus.PROHIBITION_VIOLATED
+    show = s.run_line("show audit-log")
+    assert any("received" in line for line in (show.output or []))
+
+
+def test_stepwise_commit_before_violated_forbid_with_then():
+    s = _session()
+    s.run_line('remember a list called audit-log with "none"')
+    s.run_line("remember a value called total with 15000")
+    r = s.run_line(
+        'add "logged" to audit-log then forbid total is above 10000'
+    )
+    assert r.status is ResultStatus.PROHIBITION_VIOLATED
+    show = s.run_line("show audit-log")
+    assert any("logged" in line for line in (show.output or []))
+
+
+# ---------------------------------------------------------------------------
+# Round-trip rendering
+# ---------------------------------------------------------------------------
+
+
+def test_render_round_trip_basic():
+    ast = _parse("forbid total is above 10000")
+    rendered = render(ast)
+    assert rendered == "forbid total is above 10000"
+    again = _parse(rendered)
+    assert isinstance(again, ForbidNode)
+    assert again == ast
+
+
+def test_render_round_trip_full_metadata():
+    line = (
+        'inherited forbid total is above 10000 '
+        'because "regulatory cap" from agent-compliance'
+    )
+    ast = _parse(line)
+    rendered = render(ast)
+    assert rendered == line
+    again = _parse(rendered)
+    assert isinstance(again, ForbidNode)
+    assert again.inherited is True
+    assert again.rationale == "regulatory cap"
+    assert again.inherited_from == "agent-compliance"
+
+
+# ---------------------------------------------------------------------------
+# Vocabulary
+# ---------------------------------------------------------------------------
+
+
+def test_forbid_in_verbs():
+    assert "forbid" in VERBS
+
+
+def test_forbid_reserved_category():
+    assert reserved_category("forbid") == "verb"
+
+
+def test_forbid_rejected_as_variable_name():
+    s = _session()
+    r = s.run_line("remember a value called forbid with 5")
+    assert r.status in (
+        ResultStatus.ERROR_PARSE,
+        ResultStatus.ERROR_SEMANTIC,
+    )

--- a/tests/test_inherited.py
+++ b/tests/test_inherited.py
@@ -85,8 +85,9 @@ def test_reserved_category_inherited_is_operator():
     assert reserved_category("inherited") == "operator"
 
 
-def test_all_reserved_count_is_54():
-    assert len(ALL_RESERVED) == 54
+def test_all_reserved_count_is_55():
+    # Deontic Era added the `forbid` verb (54 → 55).
+    assert len(ALL_RESERVED) == 55
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -10,13 +10,15 @@ def test_all_ten_statuses_present():
     # ERROR_RUNTIME) for Phase 2 execution. Normative Era batch 2
     # adds REQUIREMENT_NOT_MET — distinct from ERROR_SEMANTIC ("the
     # program has a bug"); REQUIREMENT_NOT_MET means "the data
-    # violates a rule" enforced by a `require` statement.
+    # violates a rule" enforced by a `require` statement. Deontic Era
+    # adds PROHIBITION_VIOLATED — the `forbid` counterpart, raised when
+    # a prohibited condition evaluates true.
     names = {s.name for s in ResultStatus}
     assert names == {
         "SUCCESS", "AMBER_PRECEDENCE", "AMBER_AMBIGUITY",
         "ERROR_PARSE", "ERROR_SEMANTIC",
         "LISTENING", "HANDLER_FIRE", "SHUTDOWN", "ERROR_RUNTIME",
-        "REQUIREMENT_NOT_MET",
+        "REQUIREMENT_NOT_MET", "PROHIBITION_VIOLATED",
     }
 
 

--- a/tests/test_vocabulary.py
+++ b/tests/test_vocabulary.py
@@ -18,13 +18,13 @@ from liminate.vocabulary import (
 
 
 def test_verb_count():
-    # 19 verbs: 18 + 1 (`transform` — final V2 promotion; per-element
-    # list mutation via arithmetic expressions).
-    assert len(VERBS) == 19
+    # 20 verbs: 19 + 1 (`forbid` — Deontic Era; prohibition verb,
+    # inverted `require`).
+    assert len(VERBS) == 20
     assert VERBS == {
         "remember", "show", "filter", "keep", "count",
         "gather", "combine", "each", "choose", "finish",
-        "add", "remove", "weakens", "require",
+        "add", "remove", "weakens", "require", "forbid",
         "assign", "expect", "sort", "compare", "transform",
     }
 
@@ -81,10 +81,10 @@ def test_multi_word_reserved():
 
 
 def test_total_reserved_count_is_54():
-    # 54 reserved words total. Meta-Structural Era batch 3 added
-    # `inherited` (OPERATORS). 19 verbs + 20 connectives + 8 operators
-    # + 3 multi-word + 3 articles + 0 v2-deferred + 1 declaration = 54.
-    assert len(ALL_RESERVED) == 54
+    # 55 reserved words total. Deontic Era added `forbid` (VERBS).
+    # 20 verbs + 20 connectives + 8 operators + 3 multi-word
+    # + 3 articles + 0 v2-deferred + 1 declaration = 55.
+    assert len(ALL_RESERVED) == 55
 
 
 def test_reserved_sets_are_disjoint():

--- a/tests/test_within_operator.py
+++ b/tests/test_within_operator.py
@@ -46,7 +46,7 @@ def _run(tmp_path, src):
 def test_within_still_connective_and_count_unchanged():
     assert reserved_category("within") == "connective"
     assert "within" in ALL_RESERVED
-    assert len(ALL_RESERVED) == 54
+    assert len(ALL_RESERVED) == 55
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

First word of the **Deontic Era**: the `forbid` verb — a prohibition operator that mirrors `require` with inverted polarity. `forbid <condition>` means "this condition must not be true." If the condition evaluates true, the program halts with `PROHIBITION_VIOLATED`; if false, silent pass.

This completes the first leg of the obligation/permission/prohibition triangle (`require` = obligation, `forbid` = prohibition, `permit` = permission, the latter in a follow-up PR).

## Changes

- **New verb:** `forbid` — evaluates a condition, halts with `PROHIBITION_VIOLATED` if true. Same condition grammar as `require` / `choose if` / `where`.
- **New AST node:** `ForbidNode(condition)` — carries `rationale` / `inherited` / `inherited_from` (`compare=False`), matching every other verb node. `because` / `inherited` / `from` attach via the existing `_parse_one_operation` chokepoint — no per-verb plumbing.
- **New ResultStatus:** `PROHIBITION_VIOLATED`
- **New exception:** `_ProhibitionViolated` — same unwind semantics as `_RequirementNotMet` (stepwise operations stay committed).
- **Vocabulary:** 20 verbs, 55 total reserved words.

## Files modified

`vocabulary.py`, `parser.py`, `interpreter.py`, `analyzer.py`, `renderer.py`, `result.py` — plus count regression-guard updates in `test_about.py`, `test_because.py`, `test_inherited.py`, `test_result.py`, `test_vocabulary.py`, `test_within_operator.py`.

## Files created

`tests/test_forbid.py` — 29 tests (parsing, analyzer, execution, stepwise, round-trip, vocabulary).

## Invariants satisfied

- **Verb count consistency** — `len(VERBS) == 20`, `len(ALL_RESERVED) == 55`, docstring/comments aligned.
- **Slot signature completeness** — `forbid → ["condition"]`.
- **Dispatch completeness** — `ForbidNode` in `_parse_verb_statement`, `_exec_op`, `_check`.
- **Renderer completeness** — `ForbidNode` in both `render` and `render_with_explicit_precedence`.
- **Metadata field pattern** — `rationale` / `inherited` / `inherited_from` with `compare=False`.
- **Status enum consistency** — `PROHIBITION_VIOLATED` surfaced (not `ERROR_SEMANTIC`).
- **Exception unwind symmetry** — `_ProhibitionViolated` caught in both `_execute_single` and `_execute_sequence`.

## Tests

`1243 passed` (1214 baseline + 29 new). Zero regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)