### PR TITLE
feat: add permit verb — deontic explicit permission (informational emission)

### DIFF
--- a/src/liminate/analyzer.py
+++ b/src/liminate/analyzer.py
@@ -79,6 +79,7 @@ from .parser import (
     RememberValueNode,
     RequireNode,
     ForbidNode,
+    PermitNode,
     SequenceNode,
     ShowNode,
     SortNode,
@@ -328,6 +329,10 @@ def _check(
         # Behavior differs only at runtime (halts on true instead
         # of false).
         _check_choose_condition(node.condition, symtab)
+    elif isinstance(node, PermitNode):
+        # Deontic Era — same condition validation as `require`/`forbid`.
+        # Behavior differs only at runtime (emits on true, never halts).
+        _check_choose_condition(node.condition, symtab)
     elif isinstance(node, ExpectNode):
         # Epistemic Era batch 3 — same condition validation as `require`.
         # Behavior differs only at runtime (divergence emits output;
@@ -513,6 +518,10 @@ def _side_effect_verb(
         # Deontic Era — `forbid` halts on true or passes silently.
         # Never produces a value.
         return "forbid"
+    if isinstance(node, PermitNode):
+        # Deontic Era — `permit` emits an output line on true or passes
+        # silently. Never produces a capturable value.
+        return "permit"
     if isinstance(node, ExpectNode):
         # Epistemic Era batch 3 — `expect` is silent on pass; emits
         # divergence output on failure. Never produces a value.

--- a/src/liminate/interpreter.py
+++ b/src/liminate/interpreter.py
@@ -94,6 +94,7 @@ from .parser import (
     RememberValueNode,
     RequireNode,
     ForbidNode,
+    PermitNode,
     SequenceNode,
     ShowNode,
     SortNode,
@@ -607,6 +608,8 @@ def _exec_op(
         return _exec_require(node, symtab, current_item)
     if isinstance(node, ForbidNode):
         return _exec_forbid(node, symtab, current_item)
+    if isinstance(node, PermitNode):
+        return _exec_permit(node, symtab, current_item)
     if isinstance(node, ExpectNode):
         return _exec_expect(node, symtab, current_item)
     if isinstance(node, AssignNode):
@@ -1397,6 +1400,26 @@ def _exec_forbid(
     if actual:
         msg += f" {actual}"
     raise _ProhibitionViolated(msg)
+
+
+def _exec_permit(
+    node: PermitNode,
+    symtab: dict[str, SymbolEntry],
+    current_item: Any,
+) -> list[str]:
+    """Deontic Era — evaluate the condition. If true, emit an output
+    line recording the explicit permission. If false, silent pass.
+    Never halts. The output message echoes the condition in canonical
+    form and reports the actual value(s) that satisfied the permission.
+    """
+    if not _eval_condition(node.condition, current_item, symtab):
+        return []
+    condition_text = render(node.condition)
+    actual = _condition_actual_values(node.condition, current_item, symtab)
+    msg = f"Permitted: {condition_text}."
+    if actual:
+        msg += f" {actual}"
+    return [msg]
 
 
 def _exec_expect(

--- a/src/liminate/parser.py
+++ b/src/liminate/parser.py
@@ -538,6 +538,22 @@ class ForbidNode(ASTNode):
 
 
 @dataclass
+class PermitNode(ASTNode):
+    """Deontic Era — explicit permission verb.
+
+    Evaluates `condition`; if true, emits an output line recording
+    the permission. If false, silent pass. Never halts. Same
+    condition AST as `require` / `forbid` / `choose if` / `where`.
+    Completes the deontic triangle: require (obligation), forbid
+    (prohibition), permit (permission).
+    """
+    condition: ASTNode
+    rationale: str | None = field(default=None, compare=False)
+    inherited: bool = field(default=False, compare=False)
+    inherited_from: str | None = field(default=None, compare=False)
+
+
+@dataclass
 class AssignNode(ASTNode):
     """Delegated Era batch 3 — assignment/delegation verb.
 
@@ -1243,6 +1259,8 @@ def _parse_verb_statement(stream: TokenStream, comp: set[str]) -> ASTNode:
         return _parse_require(stream)
     if verb.value == "forbid":
         return _parse_forbid(stream)
+    if verb.value == "permit":
+        return _parse_permit(stream)
     if verb.value == "assign":
         return _parse_assign(stream)
     if verb.value == "expect":
@@ -1926,6 +1944,31 @@ def _parse_forbid(stream: TokenStream) -> ForbidNode:
     finally:
         stream.pop_clause()
     return ForbidNode(condition=condition)
+
+
+# ---------------------------------------------------------------------------
+# permit (Deontic Era)
+# ---------------------------------------------------------------------------
+
+
+def _parse_permit(stream: TokenStream) -> PermitNode:
+    """`permit <condition>` — explicit permission verb.
+
+    Same condition grammar as `require`/`forbid`. The difference
+    is purely in runtime behavior: `permit` emits on true, never
+    halts.
+    """
+    if stream.at_end():
+        raise _ParseError(
+            "'permit' needs a condition — try: "
+            "permit <field> is <operator> <value>."
+        )
+    stream.push_clause("permit")
+    try:
+        condition = _parse_or_condition(stream)
+    finally:
+        stream.pop_clause()
+    return PermitNode(condition=condition)
 
 
 # ---------------------------------------------------------------------------
@@ -2843,6 +2886,10 @@ def _contains_mixed_precedence(node: ASTNode) -> bool:
     if isinstance(node, ForbidNode):
         # Deontic Era: `forbid` conditions follow the same
         # mixed-precedence rule as `require` / `where`.
+        return _condition_is_mixed(node.condition)
+    if isinstance(node, PermitNode):
+        # Deontic Era: `permit` conditions follow the same
+        # mixed-precedence rule as `require` / `forbid` / `where`.
         return _condition_is_mixed(node.condition)
     if isinstance(node, ExpectNode):
         # Epistemic Era batch 3: `expect` conditions follow the same

--- a/src/liminate/renderer.py
+++ b/src/liminate/renderer.py
@@ -56,6 +56,7 @@ from .parser import (
     RememberValueNode,
     RequireNode,
     ForbidNode,
+    PermitNode,
     SequenceNode,
     ShowNode,
     SortNode,
@@ -247,6 +248,9 @@ def _render_node(node: ASTNode) -> str:
     if isinstance(node, ForbidNode):
         # Deontic Era — `forbid <condition>`.
         return f"forbid {render(node.condition)}"
+    if isinstance(node, PermitNode):
+        # Deontic Era — `permit <condition>`.
+        return f"permit {render(node.condition)}"
     if isinstance(node, ExpectNode):
         # Epistemic Era batch 3 — `expect <condition>`.
         return f"expect {render(node.condition)}"
@@ -334,6 +338,8 @@ def render_with_explicit_precedence(node: ASTNode) -> str:
         return f"require {render_with_explicit_precedence(node.condition)}"
     if isinstance(node, ForbidNode):
         return f"forbid {render_with_explicit_precedence(node.condition)}"
+    if isinstance(node, PermitNode):
+        return f"permit {render_with_explicit_precedence(node.condition)}"
     if isinstance(node, ExpectNode):
         return f"expect {render_with_explicit_precedence(node.condition)}"
     if isinstance(node, AssignNode):

--- a/src/liminate/result.py
+++ b/src/liminate/result.py
@@ -37,6 +37,12 @@ class ResultStatus(Enum):
     # "the data triggers a prohibition." The deontic triple:
     # require (obligation), forbid (prohibition), permit (permission).
     PROHIBITION_VIOLATED = "prohibition_violated"
+    # Deontic Era: a `permit` condition evaluated true at runtime.
+    # Informational — the program continues with SUCCESS. Distinct from
+    # SUCCESS to mark the deontic mode in the receipt's meta envelope.
+    # The deontic triple: require (obligation), forbid (prohibition),
+    # permit (permission).
+    PERMITTED = "permitted"
 
 
 @dataclass

--- a/src/liminate/vocabulary.py
+++ b/src/liminate/vocabulary.py
@@ -57,8 +57,9 @@ Sources:
   node. Per-statement only (MS-Q2): statement-terminal, consumed after
   all verb slots are filled. Visible to rendering, inspect, and Receipts;
   not executable, not in the symbol table.
-- Deontic Era (20 verbs, 20 connectives, 55 reserved words total)
-  — `forbid` verb (prohibition, inverted `require`).
+- Deontic Era (21 verbs, 20 connectives, 56 reserved words total)
+  — `forbid` verb (prohibition, inverted `require`) and `permit`
+  verb (explicit permission, informational emission).
 - Meta-Structural Era batch 3 (19 verbs, 20 connectives, 8 operators, 1
   declaration, 54 reserved words total) — `inherited` operator. A
   statement-initial modifier marking a verb statement as carried forward
@@ -117,6 +118,12 @@ VERBS: frozenset[str] = frozenset({
     # with inverted polarity — `require` halts when false, `forbid`
     # halts when true.
     "forbid",
+    # Deontic Era: `permit` evaluates a condition and emits an output
+    # line if true; silent on false. Never halts. Completes the deontic
+    # triangle: require (obligation), forbid (prohibition), permit
+    # (permission). Independent of require/forbid — no runtime
+    # interaction.
+    "permit",
     # Delegated Era batch 3: `assign <item> to <recipient>` stores an
     # item-to-recipient mapping in the symbol table.
     "assign",
@@ -221,7 +228,7 @@ MULTI_WORD_RESERVED: frozenset[str] = frozenset({
 # table. Single, first-line-only (MS-Q1).
 DECLARATIONS: frozenset[str] = frozenset({"about"})
 
-# All 55 reserved words. 20 verbs, 20 connectives, 8 operators, 3
+# All 56 reserved words. 21 verbs, 20 connectives, 8 operators, 3
 # articles, 0 V2-reserved, 3 multi-word reserved, 1 declaration.
 # v3a §124 was 34
 # (+1 for `finish`). Liminate `add` verb addendum v1 §9: +1 for `add`
@@ -251,6 +258,8 @@ DECLARATIONS: frozenset[str] = frozenset({"about"})
 # `from` connective (MS-Q4), so no new word. Total 54.
 # Deontic Era: +1 — `forbid` verb (prohibition, inverted `require`).
 # Total 55.
+# Deontic Era batch 2: +1 — `permit` verb (explicit permission,
+# informational). Total 56.
 ALL_RESERVED: frozenset[str] = (
     VERBS | CONNECTIVES | OPERATORS | ARTICLES | V2_RESERVED
     | MULTI_WORD_RESERVED | DECLARATIONS
@@ -267,7 +276,7 @@ def reserved_category(word: str) -> str | None:
     v4a §137: active pack verbs report as "verb"; active pack nouns
     report as "noun". Pack words are only reserved while the pack that
     declared them is loaded — the base vocabulary is the canonical
-    surface (currently 55 reserved words — 20 verbs, 0 V2-reserved;
+    surface (currently 56 reserved words — 21 verbs, 0 V2-reserved;
     see module docstring).
     """
     if word in VERBS:
@@ -481,6 +490,9 @@ VERB_SIGNATURES: dict[str, list[str]] = {
     # Deontic Era: `forbid <condition>`. Same condition grammar as
     # `require` / `choose if` / `where`.
     "forbid":   ["condition"],
+    # Deontic Era: `permit <condition>`. Same condition grammar as
+    # `require` / `forbid` / `choose if` / `where`.
+    "permit":   ["condition"],
     # Delegated Era batch 3: `assign <item> to <recipient>`.
     "assign":   ["item", "recipient"],
     # Epistemic Era batch 3: `expect <condition>`. Same condition

--- a/tests/test_about.py
+++ b/tests/test_about.py
@@ -140,10 +140,11 @@ def test_reserved_category_about_is_declaration():
     assert reserved_category("about") == "declaration"
 
 
-def test_all_reserved_count_is_55():
+def test_all_reserved_count_is_56():
     # Meta-Structural Era batch 3 added the `inherited` operator (53 → 54).
     # Deontic Era added the `forbid` verb (54 → 55).
-    assert len(ALL_RESERVED) == 55
+    # Deontic Era batch 2 added the `permit` verb (55 → 56).
+    assert len(ALL_RESERVED) == 56
 
 
 def test_about_cannot_be_used_as_variable_name():

--- a/tests/test_because.py
+++ b/tests/test_because.py
@@ -81,9 +81,9 @@ def test_reserved_category_because_is_connective():
     assert reserved_category("because") == "connective"
 
 
-def test_all_reserved_count_is_55():
-    # Deontic Era added the `forbid` verb (54 → 55).
-    assert len(ALL_RESERVED) == 55
+def test_all_reserved_count_is_56():
+    # Deontic Era batch 2 added the `permit` verb (55 → 56).
+    assert len(ALL_RESERVED) == 56
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_inherited.py
+++ b/tests/test_inherited.py
@@ -85,9 +85,9 @@ def test_reserved_category_inherited_is_operator():
     assert reserved_category("inherited") == "operator"
 
 
-def test_all_reserved_count_is_55():
-    # Deontic Era added the `forbid` verb (54 → 55).
-    assert len(ALL_RESERVED) == 55
+def test_all_reserved_count_is_56():
+    # Deontic Era batch 2 added the `permit` verb (55 → 56).
+    assert len(ALL_RESERVED) == 56
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_permit.py
+++ b/tests/test_permit.py
@@ -1,0 +1,325 @@
+"""Deontic Era batch 2 — tests for the `permit` verb.
+
+`permit` completes the deontic triangle (require/forbid/permit). Unlike
+`require` (halts on false) and `forbid` (halts on true), `permit` follows
+the `expect` pattern: it emits an informational output line when the
+condition is true and passes silently when false. It NEVER halts and
+always returns SUCCESS. Covers parsing, analysis, execution (emit on
+match, silent on miss, never halts), independence from require/forbid,
+round-trip rendering, and vocabulary registration.
+"""
+
+from __future__ import annotations
+
+from liminate.analyzer import _side_effect_verb
+from liminate.cli import Session
+from liminate.parser import (
+    CompoundConditionNode,
+    ConditionNode,
+    PermitNode,
+    parse,
+)
+from liminate.renderer import render
+from liminate.reorderer import reorder
+from liminate.lexer import tokenize
+from liminate.result import LiminateResult, ResultStatus
+from liminate.vocabulary import VERBS, reserved_category
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse(line: str):
+    toks = tokenize(line)
+    reordered = reorder(toks)
+    if isinstance(reordered, LiminateResult):
+        return reordered
+    return parse(reordered)
+
+
+def _session() -> Session:
+    return Session()
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+
+def test_parses_basic_permit():
+    ast = _parse("permit expenses is below 5000")
+    assert isinstance(ast, PermitNode)
+    assert isinstance(ast.condition, ConditionNode)
+    assert ast.condition.op == "below"
+
+
+def test_parses_permit_compound_and():
+    ast = _parse('permit expenses is below 5000 and category is "travel"')
+    assert isinstance(ast, PermitNode)
+    assert isinstance(ast.condition, CompoundConditionNode)
+    assert ast.condition.connector == "and"
+
+
+def test_parses_permit_compound_or():
+    ast = _parse('permit expenses is below 5000 or category is "travel"')
+    assert isinstance(ast, PermitNode)
+    assert isinstance(ast.condition, CompoundConditionNode)
+    assert ast.condition.connector == "or"
+
+
+def test_mixed_and_or_triggers_amber():
+    r = _parse(
+        "permit x is below 1 and y is above 5 or z is below 7"
+    )
+    assert isinstance(r, LiminateResult)
+    assert r.status is ResultStatus.AMBER_PRECEDENCE
+
+
+def test_parses_permit_negated():
+    ast = _parse("permit total is not above 100")
+    assert isinstance(ast, PermitNode)
+    assert ast.condition.op == "not_above"
+
+
+def test_parses_permit_with_includes():
+    ast = _parse('permit categories includes "approved"')
+    assert isinstance(ast, PermitNode)
+    assert ast.condition.op == "includes"
+
+
+def test_parses_permit_with_within():
+    ast = _parse("permit price is within 10 of budget")
+    assert isinstance(ast, PermitNode)
+    assert ast.condition.op == "within"
+
+
+def test_parses_permit_field_access():
+    ast = _parse("permit total of order is below 5000")
+    assert isinstance(ast, PermitNode)
+
+
+def test_parse_error_when_no_condition():
+    r = _parse("permit")
+    assert isinstance(r, LiminateResult)
+    assert r.status is ResultStatus.ERROR_PARSE
+    assert "needs a condition" in (r.message or "")
+
+
+def test_because_attaches_rationale():
+    ast = _parse(
+        'permit expenses is below 5000 because "pre-approved threshold"'
+    )
+    assert isinstance(ast, PermitNode)
+    assert ast.rationale == "pre-approved threshold"
+
+
+def test_inherited_modifier():
+    ast = _parse("inherited permit expenses is below 5000")
+    assert isinstance(ast, PermitNode)
+    assert ast.inherited is True
+
+
+def test_full_canonical_metadata_order():
+    ast = _parse(
+        'inherited permit expenses is below 5000 '
+        'because "pre-approved threshold" from agent-compliance'
+    )
+    assert isinstance(ast, PermitNode)
+    assert ast.inherited is True
+    assert ast.rationale == "pre-approved threshold"
+    assert ast.inherited_from == "agent-compliance"
+
+
+# ---------------------------------------------------------------------------
+# Semantic / analyzer
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_variable_is_semantic_error():
+    s = _session()
+    r = s.run_line("permit nonexistent is below 5")
+    assert r.status is ResultStatus.ERROR_SEMANTIC
+    assert "can't find" in (r.message or "")
+
+
+def test_numeric_operator_on_text_is_semantic_error():
+    s = _session()
+    s.run_line('remember a value called label with "hello"')
+    r = s.run_line("permit label is below 5")
+    assert r.status is ResultStatus.ERROR_SEMANTIC
+
+
+def test_permit_is_void_return_verb():
+    ast = _parse("permit expenses is below 5000")
+    assert _side_effect_verb(ast, {}, set()) == "permit"
+
+
+# ---------------------------------------------------------------------------
+# Execution — the key behavioral difference: emit on true, never halt
+# ---------------------------------------------------------------------------
+
+
+def test_permit_emits_when_true():
+    s = _session()
+    s.run_line("remember a value called expenses with 3000")
+    r = s.run_line("permit expenses is below 5000")
+    assert r.status is ResultStatus.SUCCESS
+    assert r.output == ["Permitted: expenses is below 5000. expenses is 3000."]
+
+
+def test_permit_silent_when_false():
+    s = _session()
+    s.run_line("remember a value called expenses with 8000")
+    r = s.run_line("permit expenses is below 5000")
+    assert r.status is ResultStatus.SUCCESS
+    assert r.output is None
+
+
+def test_permit_never_halts():
+    s = _session()
+    s.run_line("remember a value called expenses with 3000")
+    r = s.run_line("permit expenses is below 5000")
+    assert r.status is ResultStatus.SUCCESS
+    assert r.status is not ResultStatus.PROHIBITION_VIOLATED
+    assert r.status is not ResultStatus.REQUIREMENT_NOT_MET
+
+
+def test_permit_compound_true_emits():
+    s = _session()
+    s.run_line("remember a value called expenses with 3000")
+    s.run_line('remember a value called category with "travel"')
+    r = s.run_line(
+        'permit expenses is below 5000 and category is "travel"'
+    )
+    assert r.status is ResultStatus.SUCCESS
+    assert r.output is not None and len(r.output) == 1
+
+
+def test_permit_compound_false_silent():
+    s = _session()
+    s.run_line("remember a value called expenses with 9000")
+    s.run_line('remember a value called category with "travel"')
+    r = s.run_line(
+        'permit expenses is below 5000 and category is "travel"'
+    )
+    assert r.status is ResultStatus.SUCCESS
+    assert r.output is None
+
+
+# ---------------------------------------------------------------------------
+# Sequence / independence from require + forbid
+# ---------------------------------------------------------------------------
+
+
+def test_permit_then_failing_require_emits_then_halts():
+    s = _session()
+    s.run_line("remember a value called expenses with 3000")
+    s.run_line("remember a value called total with 10")
+    r = s.run_line(
+        "permit expenses is below 5000 and require total is above 100"
+    )
+    assert r.status is ResultStatus.REQUIREMENT_NOT_MET
+    assert any("Permitted" in line for line in (r.output or []))
+
+
+def test_permit_then_firing_forbid_emits_then_halts():
+    s = _session()
+    s.run_line("remember a value called expenses with 3000")
+    s.run_line("remember a value called total with 150")
+    r = s.run_line(
+        "permit expenses is below 5000 and forbid total is above 100"
+    )
+    assert r.status is ResultStatus.PROHIBITION_VIOLATED
+    assert any("Permitted" in line for line in (r.output or []))
+
+
+def test_passing_require_then_permit_succeeds_with_output():
+    s = _session()
+    s.run_line("remember a value called total with 200")
+    s.run_line("remember a value called expenses with 3000")
+    r = s.run_line(
+        "require total is above 100 and permit expenses is below 5000"
+    )
+    assert r.status is ResultStatus.SUCCESS
+    assert any("Permitted" in line for line in (r.output or []))
+
+
+def test_permit_then_permit_both_emit():
+    s = _session()
+    s.run_line("remember a value called expenses with 3000")
+    s.run_line("remember a value called headcount with 2")
+    r = s.run_line(
+        "permit expenses is below 5000 then permit headcount is below 5"
+    )
+    assert r.status is ResultStatus.SUCCESS
+    assert len([l for l in (r.output or []) if "Permitted" in l]) == 2
+
+
+def test_all_three_deontic_verbs_independent():
+    s = _session()
+    s.run_line("remember a value called total with 200")
+    s.run_line("remember a value called restricted-count with 0")
+    s.run_line("remember a value called expenses with 3000")
+    # require passes (total > 100), forbid passes (restricted-count not
+    # above 5), permit emits (expenses < 5000). Net: SUCCESS with one
+    # Permitted line.
+    r = s.run_line(
+        "require total is above 100 and "
+        "forbid restricted-count is above 5 and "
+        "permit expenses is below 5000"
+    )
+    assert r.status is ResultStatus.SUCCESS
+    assert any("Permitted" in line for line in (r.output or []))
+
+
+# ---------------------------------------------------------------------------
+# Round-trip rendering
+# ---------------------------------------------------------------------------
+
+
+def test_render_round_trip_basic():
+    ast = _parse("permit expenses is below 5000")
+    rendered = render(ast)
+    assert rendered == "permit expenses is below 5000"
+    again = _parse(rendered)
+    assert isinstance(again, PermitNode)
+    assert again == ast
+
+
+def test_render_round_trip_full_metadata():
+    line = (
+        'inherited permit expenses is below 5000 '
+        'because "pre-approved threshold" from agent-compliance'
+    )
+    ast = _parse(line)
+    rendered = render(ast)
+    assert rendered == line
+    again = _parse(rendered)
+    assert isinstance(again, PermitNode)
+    assert again.inherited is True
+    assert again.rationale == "pre-approved threshold"
+    assert again.inherited_from == "agent-compliance"
+
+
+# ---------------------------------------------------------------------------
+# Vocabulary
+# ---------------------------------------------------------------------------
+
+
+def test_permit_in_verbs():
+    assert "permit" in VERBS
+
+
+def test_permit_reserved_category():
+    assert reserved_category("permit") == "verb"
+
+
+def test_permit_rejected_as_variable_name():
+    s = _session()
+    r = s.run_line("remember a value called permit with 5")
+    assert r.status in (
+        ResultStatus.ERROR_PARSE,
+        ResultStatus.ERROR_SEMANTIC,
+    )

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -12,13 +12,15 @@ def test_all_ten_statuses_present():
     # program has a bug"); REQUIREMENT_NOT_MET means "the data
     # violates a rule" enforced by a `require` statement. Deontic Era
     # adds PROHIBITION_VIOLATED — the `forbid` counterpart, raised when
-    # a prohibited condition evaluates true.
+    # a prohibited condition evaluates true. Deontic Era batch 2 adds
+    # PERMITTED — informational, for the receipt's deontic_mode envelope
+    # (the interpreter returns SUCCESS for `permit`, not PERMITTED).
     names = {s.name for s in ResultStatus}
     assert names == {
         "SUCCESS", "AMBER_PRECEDENCE", "AMBER_AMBIGUITY",
         "ERROR_PARSE", "ERROR_SEMANTIC",
         "LISTENING", "HANDLER_FIRE", "SHUTDOWN", "ERROR_RUNTIME",
-        "REQUIREMENT_NOT_MET", "PROHIBITION_VIOLATED",
+        "REQUIREMENT_NOT_MET", "PROHIBITION_VIOLATED", "PERMITTED",
     }
 
 

--- a/tests/test_vocabulary.py
+++ b/tests/test_vocabulary.py
@@ -18,13 +18,13 @@ from liminate.vocabulary import (
 
 
 def test_verb_count():
-    # 20 verbs: 19 + 1 (`forbid` — Deontic Era; prohibition verb,
-    # inverted `require`).
-    assert len(VERBS) == 20
+    # 21 verbs: 20 + 1 (`permit` — Deontic Era batch 2; explicit
+    # permission verb, informational emission).
+    assert len(VERBS) == 21
     assert VERBS == {
         "remember", "show", "filter", "keep", "count",
         "gather", "combine", "each", "choose", "finish",
-        "add", "remove", "weakens", "require", "forbid",
+        "add", "remove", "weakens", "require", "forbid", "permit",
         "assign", "expect", "sort", "compare", "transform",
     }
 
@@ -81,10 +81,10 @@ def test_multi_word_reserved():
 
 
 def test_total_reserved_count_is_54():
-    # 55 reserved words total. Deontic Era added `forbid` (VERBS).
-    # 20 verbs + 20 connectives + 8 operators + 3 multi-word
-    # + 3 articles + 0 v2-deferred + 1 declaration = 55.
-    assert len(ALL_RESERVED) == 55
+    # 56 reserved words total. Deontic Era batch 2 added `permit` (VERBS).
+    # 21 verbs + 20 connectives + 8 operators + 3 multi-word
+    # + 3 articles + 0 v2-deferred + 1 declaration = 56.
+    assert len(ALL_RESERVED) == 56
 
 
 def test_reserved_sets_are_disjoint():

--- a/tests/test_within_operator.py
+++ b/tests/test_within_operator.py
@@ -46,7 +46,7 @@ def _run(tmp_path, src):
 def test_within_still_connective_and_count_unchanged():
     assert reserved_category("within") == "connective"
     assert "within" in ALL_RESERVED
-    assert len(ALL_RESERVED) == 55
+    assert len(ALL_RESERVED) == 56
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Second and final word of the **Deontic Era**: the `permit` verb — an explicit permission operator that completes the deontic triangle alongside `require` (obligation) and `forbid` (prohibition). `permit <condition>` means "this condition is explicitly permitted." If the condition evaluates true, an informational output line is emitted; if false, silent pass. **`permit` never halts.**

## Key design — follows `expect`, not `require`/`forbid`

| Verb | On match | Halts? | Status |
|------|----------|--------|--------|
| `require` | (silent on pass) | halts on **false** | `REQUIREMENT_NOT_MET` |
| `forbid` | (silent on pass) | halts on **true** | `PROHIBITION_VIOLATED` |
| `permit` | **emits output** on true | **never** | `SUCCESS` |

`permit` follows the `expect` pattern (emit on match) rather than the halt-on-violation pattern. There is **no exception class** — `_exec_permit` returns `[msg]` on true and `[]` on false. No catch blocks were added to `_execute_single`/`_execute_sequence`.

## Changes

- **New verb:** `permit` — same condition grammar as `require`/`forbid`/`choose if`/`where`.
- **New AST node:** `PermitNode(condition)` — carries `rationale`/`inherited`/`inherited_from` (`compare=False`).
- **New ResultStatus:** `PERMITTED` — exists for the Receipts `deontic_mode` envelope field. The interpreter returns `SUCCESS` for `permit`, *not* `PERMITTED`.
- **Vocabulary:** 21 verbs, 56 total reserved words.
- **Deontic triangle complete:** `require` (obligation) + `forbid` (prohibition) + `permit` (permission), each an independent assertion with no runtime interaction.

## Files modified

`vocabulary.py`, `parser.py`, `interpreter.py`, `analyzer.py`, `renderer.py`, `result.py` — plus count regression-guard updates in `test_about.py`, `test_because.py`, `test_inherited.py`, `test_result.py`, `test_vocabulary.py`, `test_within_operator.py`.

## Files created

`tests/test_permit.py` — 30 tests (parsing, analyzer, emit-on-true/silent-on-false, never-halts, deontic independence with all three verbs in one sequence, round-trip, vocabulary).

## Invariants satisfied (§10)

- Verb count: `len(VERBS) == 21`, `len(ALL_RESERVED) == 56`, docstring/comments aligned.
- Slot signature: `permit → ["condition"]`.
- Dispatch completeness: `PermitNode` in `_parse_verb_statement`, `_exec_op`, `_check`.
- Renderer completeness: both `render` and `render_with_explicit_precedence`.
- Metadata field pattern: `rationale`/`inherited`/`inherited_from` with `compare=False`.
- **No exception class** — `permit` returns output, never raises.
- **Status is SUCCESS** — `PERMITTED` reserved for the receipt envelope, not interpreter return.

## Tests

`1273 passed` (1243 baseline + 30 new). Zero regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)