### PR TITLE
feat: add starting/until connectives — temporal-boundary era (effective dates and sunset clauses)

### DIFF
--- a/src/liminate/parser.py
+++ b/src/liminate/parser.py
@@ -39,6 +39,7 @@ other descriptors remain decorative.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -112,6 +113,13 @@ class RememberValueNode(ASTNode):
     # agent (MS-Q3 overridable / MS-Q4 reuse `from`).
     inherited: bool = field(default=False, compare=False)
     inherited_from: str | None = field(default=None, compare=False)
+    # Temporal-Boundary Era — `starting` and `until` connectives.
+    # Quoted ISO 8601 date strings as inert metadata (compare=False).
+    # `starting_date` is the effective date; `until_date` is the sunset.
+    # Both None when no temporal boundary is declared. Evaluation is a
+    # product-layer concern (Receipts server temporal_window field).
+    starting_date: str | None = field(default=None, compare=False)
+    until_date: str | None = field(default=None, compare=False)
 
 
 @dataclass
@@ -128,6 +136,13 @@ class RememberListNode(ASTNode):
     # agent (MS-Q3 overridable / MS-Q4 reuse `from`).
     inherited: bool = field(default=False, compare=False)
     inherited_from: str | None = field(default=None, compare=False)
+    # Temporal-Boundary Era — `starting` and `until` connectives.
+    # Quoted ISO 8601 date strings as inert metadata (compare=False).
+    # `starting_date` is the effective date; `until_date` is the sunset.
+    # Both None when no temporal boundary is declared. Evaluation is a
+    # product-layer concern (Receipts server temporal_window field).
+    starting_date: str | None = field(default=None, compare=False)
+    until_date: str | None = field(default=None, compare=False)
 
 
 @dataclass
@@ -144,6 +159,13 @@ class RememberRecordNode(ASTNode):
     # agent (MS-Q3 overridable / MS-Q4 reuse `from`).
     inherited: bool = field(default=False, compare=False)
     inherited_from: str | None = field(default=None, compare=False)
+    # Temporal-Boundary Era — `starting` and `until` connectives.
+    # Quoted ISO 8601 date strings as inert metadata (compare=False).
+    # `starting_date` is the effective date; `until_date` is the sunset.
+    # Both None when no temporal boundary is declared. Evaluation is a
+    # product-layer concern (Receipts server temporal_window field).
+    starting_date: str | None = field(default=None, compare=False)
+    until_date: str | None = field(default=None, compare=False)
 
 
 @dataclass
@@ -163,6 +185,13 @@ class RememberCompositionNode(ASTNode):
     # agent (MS-Q3 overridable / MS-Q4 reuse `from`).
     inherited: bool = field(default=False, compare=False)
     inherited_from: str | None = field(default=None, compare=False)
+    # Temporal-Boundary Era — `starting` and `until` connectives.
+    # Quoted ISO 8601 date strings as inert metadata (compare=False).
+    # `starting_date` is the effective date; `until_date` is the sunset.
+    # Both None when no temporal boundary is declared. Evaluation is a
+    # product-layer concern (Receipts server temporal_window field).
+    starting_date: str | None = field(default=None, compare=False)
+    until_date: str | None = field(default=None, compare=False)
 
 
 @dataclass
@@ -207,6 +236,13 @@ class ShowNode(ASTNode):
     # agent (MS-Q3 overridable / MS-Q4 reuse `from`).
     inherited: bool = field(default=False, compare=False)
     inherited_from: str | None = field(default=None, compare=False)
+    # Temporal-Boundary Era — `starting` and `until` connectives.
+    # Quoted ISO 8601 date strings as inert metadata (compare=False).
+    # `starting_date` is the effective date; `until_date` is the sunset.
+    # Both None when no temporal boundary is declared. Evaluation is a
+    # product-layer concern (Receipts server temporal_window field).
+    starting_date: str | None = field(default=None, compare=False)
+    until_date: str | None = field(default=None, compare=False)
 
 
 @dataclass
@@ -221,6 +257,13 @@ class FilterNode(ASTNode):
     # agent (MS-Q3 overridable / MS-Q4 reuse `from`).
     inherited: bool = field(default=False, compare=False)
     inherited_from: str | None = field(default=None, compare=False)
+    # Temporal-Boundary Era — `starting` and `until` connectives.
+    # Quoted ISO 8601 date strings as inert metadata (compare=False).
+    # `starting_date` is the effective date; `until_date` is the sunset.
+    # Both None when no temporal boundary is declared. Evaluation is a
+    # product-layer concern (Receipts server temporal_window field).
+    starting_date: str | None = field(default=None, compare=False)
+    until_date: str | None = field(default=None, compare=False)
 
 
 @dataclass
@@ -240,6 +283,13 @@ class KeepNode(ASTNode):
     # agent (MS-Q3 overridable / MS-Q4 reuse `from`).
     inherited: bool = field(default=False, compare=False)
     inherited_from: str | None = field(default=None, compare=False)
+    # Temporal-Boundary Era — `starting` and `until` connectives.
+    # Quoted ISO 8601 date strings as inert metadata (compare=False).
+    # `starting_date` is the effective date; `until_date` is the sunset.
+    # Both None when no temporal boundary is declared. Evaluation is a
+    # product-layer concern (Receipts server temporal_window field).
+    starting_date: str | None = field(default=None, compare=False)
+    until_date: str | None = field(default=None, compare=False)
 
 
 @dataclass
@@ -253,6 +303,13 @@ class CountNode(ASTNode):
     # agent (MS-Q3 overridable / MS-Q4 reuse `from`).
     inherited: bool = field(default=False, compare=False)
     inherited_from: str | None = field(default=None, compare=False)
+    # Temporal-Boundary Era — `starting` and `until` connectives.
+    # Quoted ISO 8601 date strings as inert metadata (compare=False).
+    # `starting_date` is the effective date; `until_date` is the sunset.
+    # Both None when no temporal boundary is declared. Evaluation is a
+    # product-layer concern (Receipts server temporal_window field).
+    starting_date: str | None = field(default=None, compare=False)
+    until_date: str | None = field(default=None, compare=False)
 
 
 @dataclass
@@ -268,6 +325,13 @@ class GatherNode(ASTNode):
     # agent (MS-Q3 overridable / MS-Q4 reuse `from`).
     inherited: bool = field(default=False, compare=False)
     inherited_from: str | None = field(default=None, compare=False)
+    # Temporal-Boundary Era — `starting` and `until` connectives.
+    # Quoted ISO 8601 date strings as inert metadata (compare=False).
+    # `starting_date` is the effective date; `until_date` is the sunset.
+    # Both None when no temporal boundary is declared. Evaluation is a
+    # product-layer concern (Receipts server temporal_window field).
+    starting_date: str | None = field(default=None, compare=False)
+    until_date: str | None = field(default=None, compare=False)
 
 
 @dataclass
@@ -281,6 +345,13 @@ class CombineNode(ASTNode):
     # agent (MS-Q3 overridable / MS-Q4 reuse `from`).
     inherited: bool = field(default=False, compare=False)
     inherited_from: str | None = field(default=None, compare=False)
+    # Temporal-Boundary Era — `starting` and `until` connectives.
+    # Quoted ISO 8601 date strings as inert metadata (compare=False).
+    # `starting_date` is the effective date; `until_date` is the sunset.
+    # Both None when no temporal boundary is declared. Evaluation is a
+    # product-layer concern (Receipts server temporal_window field).
+    starting_date: str | None = field(default=None, compare=False)
+    until_date: str | None = field(default=None, compare=False)
 
 
 @dataclass
@@ -295,6 +366,13 @@ class EachNode(ASTNode):
     # agent (MS-Q3 overridable / MS-Q4 reuse `from`).
     inherited: bool = field(default=False, compare=False)
     inherited_from: str | None = field(default=None, compare=False)
+    # Temporal-Boundary Era — `starting` and `until` connectives.
+    # Quoted ISO 8601 date strings as inert metadata (compare=False).
+    # `starting_date` is the effective date; `until_date` is the sunset.
+    # Both None when no temporal boundary is declared. Evaluation is a
+    # product-layer concern (Receipts server temporal_window field).
+    starting_date: str | None = field(default=None, compare=False)
+    until_date: str | None = field(default=None, compare=False)
 
 
 @dataclass
@@ -313,6 +391,13 @@ class CompositionCallNode(ASTNode):
     # agent (MS-Q3 overridable / MS-Q4 reuse `from`).
     inherited: bool = field(default=False, compare=False)
     inherited_from: str | None = field(default=None, compare=False)
+    # Temporal-Boundary Era — `starting` and `until` connectives.
+    # Quoted ISO 8601 date strings as inert metadata (compare=False).
+    # `starting_date` is the effective date; `until_date` is the sunset.
+    # Both None when no temporal boundary is declared. Evaluation is a
+    # product-layer concern (Receipts server temporal_window field).
+    starting_date: str | None = field(default=None, compare=False)
+    until_date: str | None = field(default=None, compare=False)
 
 
 @dataclass
@@ -377,6 +462,13 @@ class ChooseNode(ASTNode):
     # agent (MS-Q3 overridable / MS-Q4 reuse `from`).
     inherited: bool = field(default=False, compare=False)
     inherited_from: str | None = field(default=None, compare=False)
+    # Temporal-Boundary Era — `starting` and `until` connectives.
+    # Quoted ISO 8601 date strings as inert metadata (compare=False).
+    # `starting_date` is the effective date; `until_date` is the sunset.
+    # Both None when no temporal boundary is declared. Evaluation is a
+    # product-layer concern (Receipts server temporal_window field).
+    starting_date: str | None = field(default=None, compare=False)
+    until_date: str | None = field(default=None, compare=False)
 
 
 @dataclass
@@ -423,6 +515,13 @@ class PackVerbNode(ASTNode):
     # agent (MS-Q3 overridable / MS-Q4 reuse `from`).
     inherited: bool = field(default=False, compare=False)
     inherited_from: str | None = field(default=None, compare=False)
+    # Temporal-Boundary Era — `starting` and `until` connectives.
+    # Quoted ISO 8601 date strings as inert metadata (compare=False).
+    # `starting_date` is the effective date; `until_date` is the sunset.
+    # Both None when no temporal boundary is declared. Evaluation is a
+    # product-layer concern (Receipts server temporal_window field).
+    starting_date: str | None = field(default=None, compare=False)
+    until_date: str | None = field(default=None, compare=False)
 
 
 @dataclass
@@ -443,6 +542,13 @@ class AddNode(ASTNode):
     # agent (MS-Q3 overridable / MS-Q4 reuse `from`).
     inherited: bool = field(default=False, compare=False)
     inherited_from: str | None = field(default=None, compare=False)
+    # Temporal-Boundary Era — `starting` and `until` connectives.
+    # Quoted ISO 8601 date strings as inert metadata (compare=False).
+    # `starting_date` is the effective date; `until_date` is the sunset.
+    # Both None when no temporal boundary is declared. Evaluation is a
+    # product-layer concern (Receipts server temporal_window field).
+    starting_date: str | None = field(default=None, compare=False)
+    until_date: str | None = field(default=None, compare=False)
 
 
 @dataclass
@@ -463,6 +569,13 @@ class RemoveNode(ASTNode):
     # agent (MS-Q3 overridable / MS-Q4 reuse `from`).
     inherited: bool = field(default=False, compare=False)
     inherited_from: str | None = field(default=None, compare=False)
+    # Temporal-Boundary Era — `starting` and `until` connectives.
+    # Quoted ISO 8601 date strings as inert metadata (compare=False).
+    # `starting_date` is the effective date; `until_date` is the sunset.
+    # Both None when no temporal boundary is declared. Evaluation is a
+    # product-layer concern (Receipts server temporal_window field).
+    starting_date: str | None = field(default=None, compare=False)
+    until_date: str | None = field(default=None, compare=False)
 
 
 @dataclass
@@ -482,6 +595,13 @@ class WeakensNode(ASTNode):
     # agent (MS-Q3 overridable / MS-Q4 reuse `from`).
     inherited: bool = field(default=False, compare=False)
     inherited_from: str | None = field(default=None, compare=False)
+    # Temporal-Boundary Era — `starting` and `until` connectives.
+    # Quoted ISO 8601 date strings as inert metadata (compare=False).
+    # `starting_date` is the effective date; `until_date` is the sunset.
+    # Both None when no temporal boundary is declared. Evaluation is a
+    # product-layer concern (Receipts server temporal_window field).
+    starting_date: str | None = field(default=None, compare=False)
+    until_date: str | None = field(default=None, compare=False)
 
 
 @dataclass
@@ -500,6 +620,13 @@ class FinishNode(ASTNode):
     # agent (MS-Q3 overridable / MS-Q4 reuse `from`).
     inherited: bool = field(default=False, compare=False)
     inherited_from: str | None = field(default=None, compare=False)
+    # Temporal-Boundary Era — `starting` and `until` connectives.
+    # Quoted ISO 8601 date strings as inert metadata (compare=False).
+    # `starting_date` is the effective date; `until_date` is the sunset.
+    # Both None when no temporal boundary is declared. Evaluation is a
+    # product-layer concern (Receipts server temporal_window field).
+    starting_date: str | None = field(default=None, compare=False)
+    until_date: str | None = field(default=None, compare=False)
 
 
 @dataclass
@@ -520,6 +647,13 @@ class RequireNode(ASTNode):
     # agent (MS-Q3 overridable / MS-Q4 reuse `from`).
     inherited: bool = field(default=False, compare=False)
     inherited_from: str | None = field(default=None, compare=False)
+    # Temporal-Boundary Era — `starting` and `until` connectives.
+    # Quoted ISO 8601 date strings as inert metadata (compare=False).
+    # `starting_date` is the effective date; `until_date` is the sunset.
+    # Both None when no temporal boundary is declared. Evaluation is a
+    # product-layer concern (Receipts server temporal_window field).
+    starting_date: str | None = field(default=None, compare=False)
+    until_date: str | None = field(default=None, compare=False)
 
 
 @dataclass
@@ -535,6 +669,13 @@ class ForbidNode(ASTNode):
     rationale: str | None = field(default=None, compare=False)
     inherited: bool = field(default=False, compare=False)
     inherited_from: str | None = field(default=None, compare=False)
+    # Temporal-Boundary Era — `starting` and `until` connectives.
+    # Quoted ISO 8601 date strings as inert metadata (compare=False).
+    # `starting_date` is the effective date; `until_date` is the sunset.
+    # Both None when no temporal boundary is declared. Evaluation is a
+    # product-layer concern (Receipts server temporal_window field).
+    starting_date: str | None = field(default=None, compare=False)
+    until_date: str | None = field(default=None, compare=False)
 
 
 @dataclass
@@ -551,6 +692,13 @@ class PermitNode(ASTNode):
     rationale: str | None = field(default=None, compare=False)
     inherited: bool = field(default=False, compare=False)
     inherited_from: str | None = field(default=None, compare=False)
+    # Temporal-Boundary Era — `starting` and `until` connectives.
+    # Quoted ISO 8601 date strings as inert metadata (compare=False).
+    # `starting_date` is the effective date; `until_date` is the sunset.
+    # Both None when no temporal boundary is declared. Evaluation is a
+    # product-layer concern (Receipts server temporal_window field).
+    starting_date: str | None = field(default=None, compare=False)
+    until_date: str | None = field(default=None, compare=False)
 
 
 @dataclass
@@ -574,6 +722,13 @@ class AssignNode(ASTNode):
     # agent (MS-Q3 overridable / MS-Q4 reuse `from`).
     inherited: bool = field(default=False, compare=False)
     inherited_from: str | None = field(default=None, compare=False)
+    # Temporal-Boundary Era — `starting` and `until` connectives.
+    # Quoted ISO 8601 date strings as inert metadata (compare=False).
+    # `starting_date` is the effective date; `until_date` is the sunset.
+    # Both None when no temporal boundary is declared. Evaluation is a
+    # product-layer concern (Receipts server temporal_window field).
+    starting_date: str | None = field(default=None, compare=False)
+    until_date: str | None = field(default=None, compare=False)
 
 
 @dataclass
@@ -609,6 +764,13 @@ class SortNode(ASTNode):
     # agent (MS-Q3 overridable / MS-Q4 reuse `from`).
     inherited: bool = field(default=False, compare=False)
     inherited_from: str | None = field(default=None, compare=False)
+    # Temporal-Boundary Era — `starting` and `until` connectives.
+    # Quoted ISO 8601 date strings as inert metadata (compare=False).
+    # `starting_date` is the effective date; `until_date` is the sunset.
+    # Both None when no temporal boundary is declared. Evaluation is a
+    # product-layer concern (Receipts server temporal_window field).
+    starting_date: str | None = field(default=None, compare=False)
+    until_date: str | None = field(default=None, compare=False)
 
 
 @dataclass
@@ -630,6 +792,13 @@ class CompareNode(ASTNode):
     # agent (MS-Q3 overridable / MS-Q4 reuse `from`).
     inherited: bool = field(default=False, compare=False)
     inherited_from: str | None = field(default=None, compare=False)
+    # Temporal-Boundary Era — `starting` and `until` connectives.
+    # Quoted ISO 8601 date strings as inert metadata (compare=False).
+    # `starting_date` is the effective date; `until_date` is the sunset.
+    # Both None when no temporal boundary is declared. Evaluation is a
+    # product-layer concern (Receipts server temporal_window field).
+    starting_date: str | None = field(default=None, compare=False)
+    until_date: str | None = field(default=None, compare=False)
 
 
 @dataclass
@@ -661,6 +830,13 @@ class TransformNode(ASTNode):
     # agent (MS-Q3 overridable / MS-Q4 reuse `from`).
     inherited: bool = field(default=False, compare=False)
     inherited_from: str | None = field(default=None, compare=False)
+    # Temporal-Boundary Era — `starting` and `until` connectives.
+    # Quoted ISO 8601 date strings as inert metadata (compare=False).
+    # `starting_date` is the effective date; `until_date` is the sunset.
+    # Both None when no temporal boundary is declared. Evaluation is a
+    # product-layer concern (Receipts server temporal_window field).
+    starting_date: str | None = field(default=None, compare=False)
+    until_date: str | None = field(default=None, compare=False)
     field: str | None = None
 
 
@@ -682,6 +858,13 @@ class ExpectNode(ASTNode):
     # agent (MS-Q3 overridable / MS-Q4 reuse `from`).
     inherited: bool = field(default=False, compare=False)
     inherited_from: str | None = field(default=None, compare=False)
+    # Temporal-Boundary Era — `starting` and `until` connectives.
+    # Quoted ISO 8601 date strings as inert metadata (compare=False).
+    # `starting_date` is the effective date; `until_date` is the sunset.
+    # Both None when no temporal boundary is declared. Evaluation is a
+    # product-layer concern (Receipts server temporal_window field).
+    starting_date: str | None = field(default=None, compare=False)
+    until_date: str | None = field(default=None, compare=False)
 
 
 @dataclass
@@ -1057,6 +1240,77 @@ def _parse_operation_sequence(stream: TokenStream, comp: set[str]) -> ASTNode:
     return SequenceNode(operations=operations, connectors=connectors)
 
 
+def _try_consume_starting_until(
+    stream: TokenStream,
+) -> tuple[str | None, str | None]:
+    """Consume optional `starting "<date>"` and/or `until "<date>"`
+    clauses at statement-initial position (Temporal-Boundary Era, DT-Q4).
+
+    Returns (starting_date, until_date). Either or both may be None.
+    Raises _ParseError if `starting`/`until` is present but not followed
+    by a quoted string, or if the quoted string is not valid ISO 8601.
+
+    Canonical order: `starting` before `until`. Both before `inherited`.
+    A reversed `until ... starting ...` consumes `until` only; the
+    trailing `starting` is left in the stream and errors on the verb —
+    canonical order is enforced by grammar, not by an explicit message.
+    """
+    starting_date: str | None = None
+    until_date: str | None = None
+
+    peek = stream.peek()
+    if (
+        peek
+        and peek.type is TokenType.CONNECTIVE
+        and peek.value == "starting"
+    ):
+        stream.consume()  # eat `starting`
+        date_tok = stream.consume()
+        if date_tok is None or date_tok.type is not TokenType.QUOTED_STRING:
+            got = date_tok.value if date_tok else "end of line"
+            raise _ParseError(
+                f"'starting' needs a quoted date — try: "
+                f'starting "2025-07-01". Got: {got}.'
+            )
+        _validate_iso_date(date_tok.value, "starting")
+        starting_date = date_tok.value
+
+    peek = stream.peek()
+    if (
+        peek
+        and peek.type is TokenType.CONNECTIVE
+        and peek.value == "until"
+    ):
+        stream.consume()  # eat `until`
+        date_tok = stream.consume()
+        if date_tok is None or date_tok.type is not TokenType.QUOTED_STRING:
+            got = date_tok.value if date_tok else "end of line"
+            raise _ParseError(
+                f"'until' needs a quoted date — try: "
+                f'until "2025-12-31". Got: {got}.'
+            )
+        _validate_iso_date(date_tok.value, "until")
+        until_date = date_tok.value
+
+    return starting_date, until_date
+
+
+def _validate_iso_date(date_str: str, keyword: str) -> None:
+    """Validate that a date string is ISO 8601 format (YYYY-MM-DD).
+
+    Raises _ParseError with a helpful message if the format is wrong.
+    Does NOT validate that the date is a real calendar date (e.g.
+    2025-02-30 passes format validation but is not a real date) —
+    that's a runtime concern if needed later. The parser only checks
+    the structural format.
+    """
+    if not re.match(r'^\d{4}-\d{2}-\d{2}$', date_str):
+        raise _ParseError(
+            f"'{keyword}' needs an ISO 8601 date (YYYY-MM-DD) — "
+            f'try: {keyword} "2025-07-01". Got: "{date_str}".'
+        )
+
+
 def _try_consume_because(stream: TokenStream) -> str | None:
     """Consume an optional `because "<rationale>"` clause at the end of a
     verb statement (Meta-Structural Era batch 2, MS-Q2).
@@ -1134,6 +1388,12 @@ def _try_consume_inherited_from(stream: TokenStream) -> str | None:
 
 
 def _parse_one_operation(stream: TokenStream, comp: set[str]) -> ASTNode:
+    # Statement-initial `starting`/`until` temporal modifiers
+    # (Temporal-Boundary Era, DT-Q4). Consumed before `inherited` so the
+    # canonical order is `starting ... until ... inherited <verb> ...`.
+    # The dates are attached to the resulting node after the verb is parsed.
+    starting_date, until_date = _try_consume_starting_until(stream)
+
     # Statement-initial `inherited` modifier (Meta-Structural Era batch 3).
     # Marks the statement as carried forward from a prior context. The flag
     # is set on the resulting node after the verb + slots are parsed.
@@ -1166,6 +1426,13 @@ def _parse_one_operation(stream: TokenStream, comp: set[str]) -> ASTNode:
     if is_inherited:
         node.inherited = True
         node.inherited_from = _try_consume_inherited_from(stream)
+
+    # Attach temporal-boundary metadata (Temporal-Boundary Era). Inert —
+    # never read by execution; rendered in canonical order by the renderer.
+    if starting_date is not None:
+        node.starting_date = starting_date
+    if until_date is not None:
+        node.until_date = until_date
     return node
 
 

--- a/src/liminate/renderer.py
+++ b/src/liminate/renderer.py
@@ -86,14 +86,38 @@ def render(node: ASTNode) -> str:
 
     Meta-Structural Era batch 3: if the node is `inherited`, prepend the
     `inherited` modifier; if it carries `from` attribution, append the
-    `from <agent>` clause after the rationale. Canonical order:
-    `inherited <verb> <slots> because "<rationale>" from <agent>`.
+    `from <agent>` clause after the rationale.
+
+    Temporal-Boundary Era: `starting "<date>"` and/or `until "<date>"`
+    are the outermost statement-initial prefixes (before `inherited`).
+    Canonical order:
+    `starting "<d>" until "<d>" inherited <verb> <slots>
+     because "<rationale>" from <agent>`.
+
+    The metadata is assembled in a single pass: prefix components are
+    built left-to-right into a list, then suffix clauses are appended
+    right-to-left, so every field lands in canonical order.
     """
     rendered = _render_node(node)
 
-    if getattr(node, "inherited", False):
-        rendered = f"inherited {rendered}"
+    # Prefix components, in canonical order: starting, until, inherited.
+    prefix_parts: list[str] = []
 
+    starting = getattr(node, "starting_date", None)
+    if starting is not None:
+        prefix_parts.append(f'starting "{starting}"')
+
+    until_d = getattr(node, "until_date", None)
+    if until_d is not None:
+        prefix_parts.append(f'until "{until_d}"')
+
+    if getattr(node, "inherited", False):
+        prefix_parts.append("inherited")
+
+    if prefix_parts:
+        rendered = " ".join(prefix_parts) + " " + rendered
+
+    # Suffix clauses: because, then from.
     rationale = getattr(node, "rationale", None)
     if rationale is not None:
         rendered = f'{rendered} because "{rationale}"'

--- a/src/liminate/reorderer.py
+++ b/src/liminate/reorderer.py
@@ -39,6 +39,39 @@ def reorder(tokens: list[Token]) -> ReorderOutput:
     if not tokens:
         return tokens
 
+    # Temporal-Boundary Era: statement-initial `starting` and/or `until`
+    # connectives are pass-through prefixes (same pattern as `inherited`).
+    # Each is followed by a QUOTED_STRING date token. Strip the temporal
+    # prefix, reorder the remainder, re-prepend. Placed BEFORE the
+    # `inherited` check so the canonical order
+    # `starting ... until ... inherited <verb> ...` is preserved.
+    temporal_prefix: list[Token] = []
+    rest_start = 0
+    if (
+        tokens[0].type is TokenType.CONNECTIVE
+        and tokens[0].value == "starting"
+        and len(tokens) > 1
+        and tokens[1].type is TokenType.QUOTED_STRING
+    ):
+        temporal_prefix.extend([tokens[0], tokens[1]])
+        rest_start = 2
+
+    if (
+        rest_start < len(tokens)
+        and tokens[rest_start].type is TokenType.CONNECTIVE
+        and tokens[rest_start].value == "until"
+        and rest_start + 1 < len(tokens)
+        and tokens[rest_start + 1].type is TokenType.QUOTED_STRING
+    ):
+        temporal_prefix.extend([tokens[rest_start], tokens[rest_start + 1]])
+        rest_start = rest_start + 2
+
+    if temporal_prefix:
+        rest = reorder(tokens[rest_start:])
+        if isinstance(rest, list):
+            return temporal_prefix + rest
+        return rest  # propagate a LiminateResult error from the remainder
+
     # Meta-Structural Era batch 3: a statement-initial `inherited` operator
     # is a pass-through prefix. The canonical verb statement begins after
     # it, so reorder the remainder and re-prepend `inherited` unchanged.

--- a/src/liminate/vocabulary.py
+++ b/src/liminate/vocabulary.py
@@ -68,6 +68,10 @@ Sources:
   The `from` connective gains a new grammatical position: statement-final
   agent attribution on `inherited` statements (MS-Q4, no new word). The
   Meta-Structural Era is complete: `about`, `because`, `inherited`.
+- Temporal-Boundary Era (21 verbs, 22 connectives, 58 reserved words
+  total) — `starting` connective (effective date) and `until`
+  connective (sunset clause). Statement-initial modifiers with quoted
+  ISO 8601 dates as inert AST metadata. Hard termination (DT-Q5).
 """
 
 from dataclasses import dataclass
@@ -169,6 +173,12 @@ CONNECTIVES: frozenset[str] = frozenset({
     # Per-statement only (MS-Q2). Statement-terminal: consumed after all
     # verb slots are filled.
     "because",
+    # Temporal-Boundary Era: `starting` introduces an effective date;
+    # `until` introduces a sunset clause. Both are statement-initial
+    # modifiers attaching ISO 8601 quoted-string dates as inert AST
+    # metadata. Co-occurrence allowed. Temporal evaluation is a
+    # product-layer concern (Receipts server), not interpreter runtime.
+    "starting", "until",
 })
 
 # v1 single-word operators (inception §11). `equal to` is a multi-word
@@ -228,7 +238,7 @@ MULTI_WORD_RESERVED: frozenset[str] = frozenset({
 # table. Single, first-line-only (MS-Q1).
 DECLARATIONS: frozenset[str] = frozenset({"about"})
 
-# All 56 reserved words. 21 verbs, 20 connectives, 8 operators, 3
+# All 58 reserved words. 21 verbs, 22 connectives, 8 operators, 3
 # articles, 0 V2-reserved, 3 multi-word reserved, 1 declaration.
 # v3a §124 was 34
 # (+1 for `finish`). Liminate `add` verb addendum v1 §9: +1 for `add`
@@ -260,6 +270,8 @@ DECLARATIONS: frozenset[str] = frozenset({"about"})
 # Total 55.
 # Deontic Era batch 2: +1 — `permit` verb (explicit permission,
 # informational). Total 56.
+# Temporal-Boundary Era: +2 — `starting` connective (effective date)
+# and `until` connective (sunset clause). Total 58.
 ALL_RESERVED: frozenset[str] = (
     VERBS | CONNECTIVES | OPERATORS | ARTICLES | V2_RESERVED
     | MULTI_WORD_RESERVED | DECLARATIONS
@@ -276,7 +288,7 @@ def reserved_category(word: str) -> str | None:
     v4a §137: active pack verbs report as "verb"; active pack nouns
     report as "noun". Pack words are only reserved while the pack that
     declared them is loaded — the base vocabulary is the canonical
-    surface (currently 56 reserved words — 21 verbs, 0 V2-reserved;
+    surface (currently 58 reserved words — 21 verbs, 0 V2-reserved;
     see module docstring).
     """
     if word in VERBS:

--- a/tests/test_about.py
+++ b/tests/test_about.py
@@ -140,11 +140,12 @@ def test_reserved_category_about_is_declaration():
     assert reserved_category("about") == "declaration"
 
 
-def test_all_reserved_count_is_56():
+def test_all_reserved_count_is_58():
     # Meta-Structural Era batch 3 added the `inherited` operator (53 → 54).
     # Deontic Era added the `forbid` verb (54 → 55).
     # Deontic Era batch 2 added the `permit` verb (55 → 56).
-    assert len(ALL_RESERVED) == 56
+    # Temporal-Boundary Era added `starting`/`until` (56 → 58).
+    assert len(ALL_RESERVED) == 58
 
 
 def test_about_cannot_be_used_as_variable_name():

--- a/tests/test_because.py
+++ b/tests/test_because.py
@@ -81,9 +81,9 @@ def test_reserved_category_because_is_connective():
     assert reserved_category("because") == "connective"
 
 
-def test_all_reserved_count_is_56():
-    # Deontic Era batch 2 added the `permit` verb (55 → 56).
-    assert len(ALL_RESERVED) == 56
+def test_all_reserved_count_is_58():
+    # Temporal-Boundary Era added `starting`/`until` connectives (56 → 58).
+    assert len(ALL_RESERVED) == 58
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_inherited.py
+++ b/tests/test_inherited.py
@@ -85,9 +85,9 @@ def test_reserved_category_inherited_is_operator():
     assert reserved_category("inherited") == "operator"
 
 
-def test_all_reserved_count_is_56():
-    # Deontic Era batch 2 added the `permit` verb (55 → 56).
-    assert len(ALL_RESERVED) == 56
+def test_all_reserved_count_is_58():
+    # Temporal-Boundary Era added `starting`/`until` connectives (56 → 58).
+    assert len(ALL_RESERVED) == 58
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_starting_until.py
+++ b/tests/test_starting_until.py
@@ -1,0 +1,306 @@
+"""Temporal-Boundary Era — tests for the `starting` and `until` connectives.
+
+`starting "<date>"` declares an effective date; `until "<date>"` declares a
+sunset clause. Both are statement-initial modifiers (like `inherited`) that
+attach quoted ISO 8601 date strings as inert AST metadata. They never affect
+runtime — temporal evaluation is a product-layer concern (Receipts server).
+Canonical order: `starting ... until ... inherited <verb> ... because "..."
+from <agent>`. Co-occurrence allowed; canonical order enforced by grammar.
+"""
+
+from __future__ import annotations
+
+from liminate.cli import Session
+from liminate.lexer import tokenize
+from liminate.parser import parse
+from liminate.renderer import render
+from liminate.reorderer import reorder
+from liminate.result import LiminateResult, ResultStatus
+from liminate.vocabulary import CONNECTIVES, reserved_category
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse(line: str):
+    toks = tokenize(line)
+    reordered = reorder(toks)
+    if isinstance(reordered, LiminateResult):
+        return reordered
+    return parse(reordered)
+
+
+def _session() -> Session:
+    return Session()
+
+
+# ---------------------------------------------------------------------------
+# Parsing — `starting` only
+# ---------------------------------------------------------------------------
+
+
+def test_starting_with_require():
+    ast = _parse('starting "2025-07-01" require expenses is below 5000')
+    assert not isinstance(ast, LiminateResult)
+    assert ast.starting_date == "2025-07-01"
+    assert ast.until_date is None
+
+
+def test_starting_with_forbid():
+    ast = _parse('starting "2025-07-01" forbid expenses is above 10000')
+    assert not isinstance(ast, LiminateResult)
+    assert ast.starting_date == "2025-07-01"
+
+
+def test_starting_with_permit():
+    ast = _parse('starting "2025-07-01" permit expenses is below 5000')
+    assert not isinstance(ast, LiminateResult)
+    assert ast.starting_date == "2025-07-01"
+
+
+def test_starting_with_remember():
+    ast = _parse('starting "2025-07-01" remember a value called threshold with 5')
+    assert not isinstance(ast, LiminateResult)
+    assert ast.starting_date == "2025-07-01"
+
+
+def test_starting_without_date_is_parse_error():
+    r = _parse("starting require expenses is below 5000")
+    assert isinstance(r, LiminateResult)
+    assert r.status is ResultStatus.ERROR_PARSE
+
+
+def test_starting_bad_format_is_parse_error():
+    r = _parse('starting "not-a-date" require expenses is below 5000')
+    assert isinstance(r, LiminateResult)
+    assert r.status is ResultStatus.ERROR_PARSE
+
+
+def test_starting_bare_number_is_parse_error():
+    r = _parse("starting 2025 require expenses is below 5000")
+    assert isinstance(r, LiminateResult)
+    assert r.status is ResultStatus.ERROR_PARSE
+
+
+# ---------------------------------------------------------------------------
+# Parsing — `until` only
+# ---------------------------------------------------------------------------
+
+
+def test_until_with_require():
+    ast = _parse('until "2025-12-31" require expenses is below 5000')
+    assert not isinstance(ast, LiminateResult)
+    assert ast.until_date == "2025-12-31"
+    assert ast.starting_date is None
+
+
+def test_until_without_date_is_parse_error():
+    r = _parse("until require expenses is below 5000")
+    assert isinstance(r, LiminateResult)
+    assert r.status is ResultStatus.ERROR_PARSE
+
+
+def test_until_bad_format_is_parse_error():
+    r = _parse('until "bad-format" require expenses is below 5000')
+    assert isinstance(r, LiminateResult)
+    assert r.status is ResultStatus.ERROR_PARSE
+
+
+# ---------------------------------------------------------------------------
+# Parsing — co-occurrence (DT-Q4)
+# ---------------------------------------------------------------------------
+
+
+def test_starting_and_until_co_occur():
+    ast = _parse(
+        'starting "2025-07-01" until "2025-12-31" '
+        "require expenses is below 5000"
+    )
+    assert not isinstance(ast, LiminateResult)
+    assert ast.starting_date == "2025-07-01"
+    assert ast.until_date == "2025-12-31"
+
+
+def test_reversed_order_until_before_starting_is_parse_error():
+    # Canonical order is `starting` before `until`. A reversed order
+    # consumes `until` only; the trailing `starting` is left in the
+    # stream and errors on the verb.
+    r = _parse(
+        'until "2025-12-31" starting "2025-07-01" '
+        "require expenses is below 5000"
+    )
+    assert isinstance(r, LiminateResult)
+    assert r.status is ResultStatus.ERROR_PARSE
+
+
+# ---------------------------------------------------------------------------
+# Parsing — combination with all metadata
+# ---------------------------------------------------------------------------
+
+
+def test_all_six_metadata_fields():
+    ast = _parse(
+        'starting "2025-07-01" until "2025-12-31" inherited '
+        'require expenses is below 5000 because "cap" from agent-compliance'
+    )
+    assert not isinstance(ast, LiminateResult)
+    assert ast.starting_date == "2025-07-01"
+    assert ast.until_date == "2025-12-31"
+    assert ast.inherited is True
+    assert ast.rationale == "cap"
+    assert ast.inherited_from == "agent-compliance"
+
+
+def test_starting_inherited_because_from():
+    ast = _parse(
+        'starting "2025-07-01" inherited forbid headcount is above 50 '
+        'because "sunset" from agent-hr'
+    )
+    assert not isinstance(ast, LiminateResult)
+    assert ast.starting_date == "2025-07-01"
+    assert ast.until_date is None
+    assert ast.inherited is True
+    assert ast.rationale == "sunset"
+    assert ast.inherited_from == "agent-hr"
+
+
+def test_until_with_because():
+    ast = _parse(
+        'until "2025-12-31" permit expenses is below 5000 '
+        'because "temporary allowance"'
+    )
+    assert not isinstance(ast, LiminateResult)
+    assert ast.until_date == "2025-12-31"
+    assert ast.rationale == "temporary allowance"
+
+
+# ---------------------------------------------------------------------------
+# Parsing — no temporal markers (backward compat)
+# ---------------------------------------------------------------------------
+
+
+def test_no_temporal_markers_defaults_none():
+    ast = _parse("require expenses is below 5000")
+    assert not isinstance(ast, LiminateResult)
+    assert ast.starting_date is None
+    assert ast.until_date is None
+
+
+# ---------------------------------------------------------------------------
+# Runtime — inert metadata (does not affect execution)
+# ---------------------------------------------------------------------------
+
+
+def test_starting_does_not_affect_passing_require():
+    s = _session()
+    s.run_line("remember a value called expenses with 3000")
+    r = s.run_line('starting "2025-07-01" require expenses is below 5000')
+    assert r.status is ResultStatus.SUCCESS
+
+
+def test_starting_does_not_prevent_requirement_enforcement():
+    s = _session()
+    s.run_line("remember a value called expenses with 8000")
+    r = s.run_line('starting "2025-07-01" require expenses is below 5000')
+    assert r.status is ResultStatus.REQUIREMENT_NOT_MET
+
+
+def test_until_does_not_prevent_prohibition_enforcement():
+    s = _session()
+    s.run_line("remember a value called expenses with 15000")
+    r = s.run_line('until "2025-12-31" forbid expenses is above 10000')
+    assert r.status is ResultStatus.PROHIBITION_VIOLATED
+
+
+# ---------------------------------------------------------------------------
+# Reorderer
+# ---------------------------------------------------------------------------
+
+
+def test_reorder_preserves_temporal_prefix_with_target_before_verb():
+    ast = _parse(
+        'starting "2025-07-01" the orders filter where total is above 50'
+    )
+    assert not isinstance(ast, LiminateResult)
+    assert ast.starting_date == "2025-07-01"
+    # The verb was reordered to canonical position; the date survived.
+    assert render(ast).startswith('starting "2025-07-01" filter the orders')
+
+
+def test_reorder_preserves_all_three_prefixes():
+    ast = _parse(
+        'starting "2025-07-01" until "2025-12-31" inherited '
+        "the orders filter where total is above 50"
+    )
+    assert not isinstance(ast, LiminateResult)
+    assert ast.starting_date == "2025-07-01"
+    assert ast.until_date == "2025-12-31"
+    assert ast.inherited is True
+
+
+# ---------------------------------------------------------------------------
+# Renderer round-trip
+# ---------------------------------------------------------------------------
+
+
+def _round_trip(line: str):
+    ast = _parse(line)
+    assert not isinstance(ast, LiminateResult), f"parse failed: {line}"
+    rendered = render(ast)
+    assert rendered == line, f"render mismatch:\n  in : {line}\n  out: {rendered}"
+    again = _parse(rendered)
+    assert not isinstance(again, LiminateResult)
+    assert again == ast
+
+
+def test_round_trip_starting_only():
+    _round_trip('starting "2025-07-01" require expenses is below 5000')
+
+
+def test_round_trip_until_only():
+    _round_trip('until "2025-12-31" forbid expenses is above 10000')
+
+
+def test_round_trip_both():
+    _round_trip(
+        'starting "2025-07-01" until "2025-12-31" '
+        "require expenses is below 5000"
+    )
+
+
+def test_round_trip_full_canonical():
+    _round_trip(
+        'starting "2025-07-01" until "2025-12-31" inherited '
+        'require expenses is below 5000 because "cap" from agent-compliance'
+    )
+
+
+# ---------------------------------------------------------------------------
+# Vocabulary
+# ---------------------------------------------------------------------------
+
+
+def test_starting_in_connectives():
+    assert "starting" in CONNECTIVES
+
+
+def test_until_in_connectives():
+    assert "until" in CONNECTIVES
+
+
+def test_starting_reserved_category():
+    assert reserved_category("starting") == "connective"
+
+
+def test_until_reserved_category():
+    assert reserved_category("until") == "connective"
+
+
+def test_temporal_words_rejected_as_variable_names():
+    s = _session()
+    r1 = s.run_line("remember a value called starting with 5")
+    r2 = s.run_line("remember a value called until with 5")
+    assert r1.status in (ResultStatus.ERROR_PARSE, ResultStatus.ERROR_SEMANTIC)
+    assert r2.status in (ResultStatus.ERROR_PARSE, ResultStatus.ERROR_SEMANTIC)

--- a/tests/test_vocabulary.py
+++ b/tests/test_vocabulary.py
@@ -30,16 +30,16 @@ def test_verb_count():
 
 
 def test_connective_count():
-    # 20 connectives: 19 + 1 (`because` — Meta-Structural Era batch 2;
-    # attaches a quoted rationale to a verb statement as inert AST
-    # metadata, statement-terminal, per-statement only per MS-Q2).
-    assert len(CONNECTIVES) == 20
+    # 22 connectives: 20 + 2 (`starting`/`until` — Temporal-Boundary
+    # Era; statement-initial modifiers attaching quoted ISO 8601 dates
+    # as inert AST metadata, co-occurrence allowed per DT-Q4).
+    assert len(CONNECTIVES) == 22
     assert CONNECTIVES == {
         "where", "and", "or", "from", "with",
         "called", "to", "how", "as", "of",
         "if", "otherwise",
         "when", "unless", "includes", "within", "over", "then",
-        "by", "because",
+        "by", "because", "starting", "until",
     }
 
 
@@ -81,10 +81,10 @@ def test_multi_word_reserved():
 
 
 def test_total_reserved_count_is_54():
-    # 56 reserved words total. Deontic Era batch 2 added `permit` (VERBS).
-    # 21 verbs + 20 connectives + 8 operators + 3 multi-word
-    # + 3 articles + 0 v2-deferred + 1 declaration = 56.
-    assert len(ALL_RESERVED) == 56
+    # 58 reserved words total. Temporal-Boundary Era added `starting`
+    # and `until` (CONNECTIVES). 21 verbs + 22 connectives + 8 operators
+    # + 3 multi-word + 3 articles + 0 v2-deferred + 1 declaration = 58.
+    assert len(ALL_RESERVED) == 58
 
 
 def test_reserved_sets_are_disjoint():

--- a/tests/test_within_operator.py
+++ b/tests/test_within_operator.py
@@ -46,7 +46,7 @@ def _run(tmp_path, src):
 def test_within_still_connective_and_count_unchanged():
     assert reserved_category("within") == "connective"
     assert "within" in ALL_RESERVED
-    assert len(ALL_RESERVED) == 56
+    assert len(ALL_RESERVED) == 58
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two new connectives — **`starting`** and **`until`** — that give rules explicit effective dates and sunset clauses. `starting "2025-07-01"` declares when a rule takes effect; `until "2025-12-31"` declares when it expires. Both are **statement-initial modifiers** (like `inherited`) that attach quoted ISO 8601 date strings as **inert AST metadata**.

Temporal evaluation (is this rule currently active?) is a product-layer concern handled by the Receipts server `temporal_window` field — the interpreter stores the dates, it does not evaluate them against a clock.

## Design (all LOCKED — DT-Q4, DT-Q5, DT-Q9)

- **Statement-initial.** Consumed by `_parse_one_operation` before `inherited`. Canonical order: `starting "<d>" until "<d>" inherited <verb> <slots> because "<rationale>" from <agent>`.
- **Co-occurrence allowed (DT-Q4).** A statement may have `starting` only, `until` only, both, or neither. Canonical order (`starting` before `until`) is enforced by grammar — a reversed order is a parse error.
- **Quoted ISO 8601 dates.** Validated for `YYYY-MM-DD` format at parse time via `_validate_iso_date`. (Format only — `2025-02-30` passes structural validation; calendar validity is a later runtime concern if needed.)
- **Hard termination (DT-Q5).** `until` is binary — active or expired. No decay; decay composes via `weakens`.
- **Grammatical category: CONNECTIVE.** They introduce a quoted value (the connective pattern), unlike `inherited` which is a bare operator.
- **Inert metadata.** `starting_date` / `until_date` are `compare=False` fields on all 26 verb AST nodes.

## Changes

- **All 26 verb AST nodes** gain `starting_date` and `until_date` fields (same pattern as `rationale`/`inherited`/`inherited_from`).
- **Parser:** `_try_consume_starting_until` + `_validate_iso_date`, integrated into the `_parse_one_operation` chokepoint before `inherited`.
- **Reorderer:** strips the temporal prefix (CONNECTIVE + QUOTED_STRING pairs) as a pass-through, before the `inherited` check — preserving canonical order through verb-position correction.
- **Renderer:** unified metadata assembly using a prefix-parts list, producing the full six-field canonical order in one pass.
- **No interpreter or analyzer changes** — the metadata is inert; a program with temporal boundaries executes identically to one without.
- **Vocabulary:** 21 verbs, 22 connectives, 58 total reserved words.

## Files modified

`vocabulary.py`, `parser.py`, `renderer.py`, `reorderer.py` — plus count regression-guard updates in `test_about.py`, `test_because.py`, `test_inherited.py`, `test_vocabulary.py`, `test_within_operator.py`.

## Files created

`tests/test_starting_until.py` — 30 tests (starting-only, until-only, co-occurrence, all-six-metadata combination, backward-compat, inert-runtime, reorderer prefix preservation, round-trip, vocabulary).

## Invariants satisfied (§9)

- Connective count: `len(CONNECTIVES) == 22`, `len(ALL_RESERVED) == 58`.
- AST field completeness: all 26 nodes carry both fields (verified count).
- Metadata assembly order: full canonical round-trip is byte-exact and AST-equal.
- Reorderer prefix stripping: 2 tokens per temporal keyword, `inherited` is 1 token.
- No runtime effect: enforcement tests confirm `require`/`forbid` still fire with temporal markers present.
- Format validation at parse time: bad formats and bare numbers → `ERROR_PARSE`.

## Tests

`1303 passed` (1273 baseline + 30 new). Zero regressions. The full six-field canonical round-trip was verified explicitly per §11.

## Era status

**Temporal-Boundary Era complete.** Projected vocabulary matches the v6 design: 58 base reserved words (21 verbs, 22 connectives, 8 operators, 3 articles, 3 multi-word, 1 declaration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)