### PR TITLE
feat: add `require each` grammar extension — iterated enforcement with named binding

### DIFF
--- a/src/liminate/analyzer.py
+++ b/src/liminate/analyzer.py
@@ -78,6 +78,7 @@ from .parser import (
     RememberRecordNode,
     RememberValueNode,
     RequireNode,
+    RequireEachNode,
     ForbidNode,
     PermitNode,
     SequenceNode,
@@ -153,6 +154,11 @@ class IteratorContext:
     record_schemas: list[dict[str, str]] | None = None
     # For flat lists: type of the items ("number" or "string").
     scalar_type: str | None = None
+    # v8a §49: for `require each`, the name bound to the current element.
+    # When set, a NameRef matching it resolves to the current element
+    # (the same target as the `each` pronoun) rather than erroring or
+    # being checked against a record schema.
+    binding_name: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -324,6 +330,11 @@ def _check(
         # validation path as `choose if`: no iterator, names resolve
         # against the symbol table directly, field access uses `of`.
         _check_choose_condition(node.condition, symtab)
+    elif isinstance(node, RequireEachNode):
+        # v8a §49 — iterated enforcement. Validate the collection is a
+        # list and the binding name doesn't collide with it; the
+        # condition resolves against the bound element.
+        _check_require_each(node, symtab)
     elif isinstance(node, ForbidNode):
         # Deontic Era — same condition validation as `require`.
         # Behavior differs only at runtime (halts on true instead
@@ -1150,6 +1161,13 @@ def _resolve_field(
         return iterator.scalar_type or "unknown", "each"
     if isinstance(field_node, NameRef):
         name = field_node.name
+        if iterator.binding_name is not None and name == iterator.binding_name:
+            # v8a §49 — an explicit reference to the `require each`
+            # binding resolves to the current element, exactly like the
+            # `each` pronoun.
+            if iterator.record_schemas is not None:
+                return "record", name
+            return iterator.scalar_type or "unknown", name
         if iterator.record_schemas is not None:
             in_all = all(name in s for s in iterator.record_schemas)
             if in_all:
@@ -1267,6 +1285,65 @@ def _check_each(
         in_action_block=in_action_block,
         live_value_names=live_value_names,
     )
+
+
+def _check_require_each(
+    node: RequireEachNode,
+    symtab: dict[str, SymbolEntry],
+) -> None:
+    """v8a §49 — semantic checks for `require each {name} in {list}
+    {condition}`:
+
+    (a) the collection exists and is a list;
+    (b) the binding name is not identical to the list name (which would
+        read ambiguously);
+    (c) the condition is well-formed against the bound element. The
+        binding is injected as a temporary symbol-table entry and named
+        on the iterator context so both implicit (`each`) and explicit
+        (the binding name) references resolve to the current element.
+    """
+    name = node.collection.name
+    entry = _require_list(name, symtab, verb="iterate over")
+
+    if node.binding_name == name:
+        raise _SemanticError(
+            f"The binding name can't be the same as the list name. "
+            f"Try: require each <item> in {name} <condition>."
+        )
+
+    iterator = _make_iterator(name, entry)
+    iterator.binding_name = node.binding_name
+
+    # Inject a temporary binding so right-hand references (a BareWord
+    # naming the binding) and `<field> of <binding>` access resolve. The
+    # type mirrors the collection's element type. Save/restore any
+    # existing symbol with the same name (v2d §96 pattern).
+    if entry.type == "list_of_records":
+        element_type = "record"
+        element_schema = (
+            {k: _value_type(v) for k, v in entry.value[0].items()}
+            if entry.value
+            else None
+        )
+    elif entry.type == "list_of_strings":
+        element_type, element_schema = "string", None
+    else:
+        element_type, element_schema = "number", None
+
+    saved = symtab.get(node.binding_name)
+    symtab[node.binding_name] = SymbolEntry(
+        name=node.binding_name,
+        value=None,
+        type=element_type,
+        schema=element_schema,
+    )
+    try:
+        _check_condition(node.condition, symtab, iterator)
+    finally:
+        if saved is not None:
+            symtab[node.binding_name] = saved
+        else:
+            symtab.pop(node.binding_name, None)
 
 
 # ---------------------------------------------------------------------------

--- a/src/liminate/interpreter.py
+++ b/src/liminate/interpreter.py
@@ -93,6 +93,7 @@ from .parser import (
     RememberRecordNode,
     RememberValueNode,
     RequireNode,
+    RequireEachNode,
     ForbidNode,
     PermitNode,
     SequenceNode,
@@ -606,6 +607,8 @@ def _exec_op(
         return _exec_weakens(node, symtab)
     if isinstance(node, RequireNode):
         return _exec_require(node, symtab, current_item)
+    if isinstance(node, RequireEachNode):
+        return _exec_require_each(node, symtab)
     if isinstance(node, ForbidNode):
         return _exec_forbid(node, symtab, current_item)
     if isinstance(node, PermitNode):
@@ -1380,6 +1383,55 @@ def _exec_require(
     if actual:
         msg += f" {actual}"
     raise _RequirementNotMet(msg)
+
+
+def _exec_require_each(
+    node: RequireEachNode,
+    symtab: dict[str, SymbolEntry],
+) -> list[str]:
+    """v8a §49 — iterated enforcement. Evaluate the condition once per
+    element in the collection, binding the current element under
+    `binding_name` (a temporary symbol-table entry) and as the iterator
+    `current_item`. Silent if every element passes; raises
+    _RequirementNotMet identifying the first failing element otherwise.
+
+    The temporary binding uses save/restore semantics (composition
+    parameter pattern, v2d §96) so an existing symbol with the same name
+    survives the require-each evaluation. The `finally` guarantees the
+    binding never leaks, even when the condition fails or an unexpected
+    error unwinds the loop.
+    """
+    the_list = symtab[node.collection.name].value
+
+    saved = symtab.get(node.binding_name)
+    try:
+        for i, item in enumerate(the_list):
+            item_type, item_schema = _infer_type_and_schema(item)
+            symtab[node.binding_name] = SymbolEntry(
+                name=node.binding_name,
+                value=item,
+                type=item_type,
+                schema=item_schema,
+            )
+            if not _eval_condition(node.condition, item, symtab):
+                condition_text = render(node.condition)
+                actual = _condition_actual_values(node.condition, item, symtab)
+                # 1-indexed for human readability.
+                msg = (
+                    f"Requirement not met: require each {node.binding_name} "
+                    f"in {node.collection.name} {condition_text}. "
+                    f"Failed at element {i + 1}."
+                )
+                if actual:
+                    msg += f" {actual}"
+                raise _RequirementNotMet(msg)
+    finally:
+        if saved is not None:
+            symtab[node.binding_name] = saved
+        else:
+            symtab.pop(node.binding_name, None)
+
+    return []
 
 
 def _exec_forbid(

--- a/src/liminate/parser.py
+++ b/src/liminate/parser.py
@@ -657,6 +657,32 @@ class RequireNode(ASTNode):
 
 
 @dataclass
+class RequireEachNode(ASTNode):
+    """v8a §49 — iterated enforcement verb.
+
+    Evaluates `condition` once per element in `collection`, with
+    `binding_name` bound to the current element as a temporary
+    symbol-table entry. If any element violates the condition,
+    execution halts with REQUIREMENT_NOT_MET. If all pass, silent.
+
+    The condition uses the same unified condition grammar as
+    RequireNode / ForbidNode / FilterNode / ChooseNode — inherited
+    wholesale from `_parse_or_condition`. A condition that elides its
+    field (begins with `is`/`includes`) binds to the current element
+    via an implicit `EachPronoun`; an explicit reference to
+    `binding_name` resolves to the same element (a NameRef).
+    """
+    binding_name: str
+    collection: NameRef
+    condition: ASTNode
+    rationale: str | None = field(default=None, compare=False)
+    inherited: bool = field(default=False, compare=False)
+    inherited_from: str | None = field(default=None, compare=False)
+    starting_date: str | None = field(default=None, compare=False)
+    until_date: str | None = field(default=None, compare=False)
+
+
+@dataclass
 class ForbidNode(ASTNode):
     """Deontic Era — prohibition verb.
 
@@ -2165,7 +2191,7 @@ def _parse_weakens(stream: TokenStream) -> WeakensNode:
 # ---------------------------------------------------------------------------
 
 
-def _parse_require(stream: TokenStream) -> RequireNode:
+def _parse_require(stream: TokenStream) -> RequireNode | RequireEachNode:
     """`require <condition>` — enforcement verb.
 
     The condition uses the same parser path as `choose if` /
@@ -2174,18 +2200,83 @@ def _parse_require(stream: TokenStream) -> RequireNode:
     full set of comparison operators. The clause-context stack is
     pushed so condition sub-parsers can see they're inside a
     `require` clause if they ever need to.
+
+    v8a §49 — a second parse shape, `require each {name} in {list}
+    {condition}`, is selected when the next token is the `each` verb.
     """
     if stream.at_end():
         raise _ParseError(
             "'require' needs a condition — try: "
             "require <field> is <operator> <value>."
         )
+
+    # Second parse shape: `require each {name} in {list} {condition}`.
+    peek = stream.peek()
+    if peek and peek.type is TokenType.VERB and peek.value == "each":
+        return _parse_require_each(stream)
+
     stream.push_clause("require")
     try:
         condition = _parse_or_condition(stream)
     finally:
         stream.pop_clause()
     return RequireNode(condition=condition)
+
+
+def _parse_require_each(stream: TokenStream) -> RequireEachNode:
+    """Parse `require each {name} in {list} {condition}` (v8a §49).
+
+    `each` has been peeked but not consumed. Consume it, then the
+    binding name (UNKNOWN, reserved-word-excluded), the positional `in`
+    (UNKNOWN token, not a connective), the collection name, and finally
+    the condition via the unified `_parse_or_condition` path.
+
+    The `require-each` clause is pushed so `_parse_simple_condition`
+    treats a field-elided condition (one that begins with `is` /
+    `includes`) as referring to the current element via `EachPronoun`.
+    """
+    stream.consume()  # eat `each`
+
+    # Binding name — an UNKNOWN token, never a reserved word.
+    binding_name = _consume_name(stream, after="'require each'")
+
+    # `in` — consumed positionally as an UNKNOWN token (it is not a
+    # reserved connective; the same way `sort` consumes `in`).
+    in_tok = stream.consume()
+    if in_tok is None:
+        raise _ParseError(
+            "'require each' needs a list — try: "
+            f"require each {binding_name} in <list-name> <condition>."
+        )
+    if not (in_tok.type is TokenType.UNKNOWN and in_tok.value == "in"):
+        raise _ParseError(
+            f"I expected 'in' after 'require each {binding_name}', "
+            f"not '{in_tok.value}'. Try: "
+            f"require each {binding_name} in <list-name> <condition>."
+        )
+
+    # Collection name.
+    _consume_optional_article(stream)
+    collection = _consume_target(stream, verb="require each")
+
+    # Condition — same unified path as the simple `require`.
+    if stream.at_end():
+        raise _ParseError(
+            f"'require each {binding_name} in {collection.name}' "
+            f"needs a condition — try: require each {binding_name} "
+            f"in {collection.name} is <operator> <value>."
+        )
+    stream.push_clause("require-each")
+    try:
+        condition = _parse_or_condition(stream)
+    finally:
+        stream.pop_clause()
+
+    return RequireEachNode(
+        binding_name=binding_name,
+        collection=collection,
+        condition=condition,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -2713,9 +2804,21 @@ def _parse_and_condition(stream: TokenStream) -> ASTNode:
 
 def _parse_simple_condition(stream: TokenStream) -> ConditionNode:
     # Field reference or `each` pronoun (v1b §37).
-    head = stream.consume()
+    head = stream.peek()
     if head is None:
         raise _ParseError("I expected a field after 'where'.")
+    # v8a §49 — inside `require each`, a condition may elide its field:
+    # `is above 70` / `includes "x"` with no LHS binds to the current
+    # element via an implicit `each` pronoun. Detect the elided form by a
+    # leading comparison/membership token and inject EachPronoun without
+    # consuming it, so the operator-parsing below proceeds normally.
+    if stream.in_clause("require-each") and (
+        (head.type is TokenType.OPERATOR and head.value in ("is", "not"))
+        or (head.type is TokenType.CONNECTIVE and head.value == "includes")
+    ):
+        field_node: ASTNode = EachPronoun()
+        return _finish_simple_condition(stream, field_node)
+    head = stream.consume()
     if head.type is TokenType.VERB and head.value == "each":
         field_node: ASTNode = EachPronoun()
     elif head.type is TokenType.UNKNOWN:
@@ -2769,6 +2872,13 @@ def _parse_simple_condition(stream: TokenStream) -> ConditionNode:
             )
         raise _ParseError(f"I didn't expect '{head.value}' as a field name.")
 
+    return _finish_simple_condition(stream, field_node)
+
+
+def _finish_simple_condition(stream: TokenStream, field_node: ASTNode) -> ConditionNode:
+    """Parse the operator + value tail of a simple condition, given an
+    already-resolved field node. Shared between the explicit-field path
+    and the `require each` field-elided path (v8a §49)."""
     # `includes` is a list-membership connective; it replaces the entire
     # `is <op>` pattern: `<list> includes <value>` or
     # `<list> not includes <value>`.
@@ -3149,6 +3259,10 @@ def _contains_mixed_precedence(node: ASTNode) -> bool:
     if isinstance(node, RequireNode):
         # Normative Era batch 2: `require` conditions follow the same
         # mixed-precedence rule as `where` / `choose if` clauses (v1a §30).
+        return _condition_is_mixed(node.condition)
+    if isinstance(node, RequireEachNode):
+        # v8a §49: `require each` conditions follow the same
+        # mixed-precedence rule as the simple `require`.
         return _condition_is_mixed(node.condition)
     if isinstance(node, ForbidNode):
         # Deontic Era: `forbid` conditions follow the same

--- a/src/liminate/renderer.py
+++ b/src/liminate/renderer.py
@@ -55,6 +55,7 @@ from .parser import (
     RememberRecordNode,
     RememberValueNode,
     RequireNode,
+    RequireEachNode,
     ForbidNode,
     PermitNode,
     SequenceNode,
@@ -269,6 +270,12 @@ def _render_node(node: ASTNode) -> str:
     if isinstance(node, RequireNode):
         # Normative Era batch 2 — `require <condition>`.
         return f"require {render(node.condition)}"
+    if isinstance(node, RequireEachNode):
+        # v8a §49 — `require each <name> in <list> <condition>`.
+        return (
+            f"require each {node.binding_name} in "
+            f"{node.collection.name} {render(node.condition)}"
+        )
     if isinstance(node, ForbidNode):
         # Deontic Era — `forbid <condition>`.
         return f"forbid {render(node.condition)}"

--- a/tests/test_require_each.py
+++ b/tests/test_require_each.py
@@ -1,0 +1,336 @@
+"""v8a §49 (EXP-Q1 resolution) — tests for the `require each` grammar
+extension: iterated enforcement with a named binding.
+
+    require each {name} in {list} {condition}
+
+Covers parsing (the second parse shape, error paths, reserved-word
+binding), analysis (collection-is-a-list, binding ≠ collection name),
+execution (silent pass, REQUIREMENT_NOT_MET identifying the failing
+element, scalar and record lists, compound conditions, empty lists,
+binding hygiene), metadata modifiers (because / inherited / starting /
+until), mixed-precedence amber, and regression guards for the unchanged
+single-condition `require`, the `each` verb, and the `each` pronoun.
+"""
+
+from __future__ import annotations
+
+from liminate.cli import Session
+from liminate.lexer import tokenize
+from liminate.parser import (
+    CompoundConditionNode,
+    ConditionNode,
+    EachPronoun,
+    NameRef,
+    RequireEachNode,
+    RequireNode,
+    parse,
+)
+from liminate.renderer import render
+from liminate.reorderer import reorder
+from liminate.result import LiminateResult, ResultStatus
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse(line: str):
+    toks = tokenize(line)
+    reordered = reorder(toks)
+    if isinstance(reordered, LiminateResult):
+        return reordered
+    return parse(reordered)
+
+
+def _session() -> Session:
+    return Session()
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+
+def test_parses_basic_scalar_list():
+    ast = _parse("require each score in scores is above 70")
+    assert isinstance(ast, RequireEachNode)
+    assert ast.binding_name == "score"
+    assert isinstance(ast.collection, NameRef)
+    assert ast.collection.name == "scores"
+    assert isinstance(ast.condition, ConditionNode)
+    assert ast.condition.op == "above"
+    # Field is elided → bound to the current element via EachPronoun.
+    assert isinstance(ast.condition.field, EachPronoun)
+
+
+def test_parses_basic_record_list():
+    ast = _parse("require each hazard in machine-hazards is guarded")
+    assert isinstance(ast, RequireEachNode)
+    assert ast.binding_name == "hazard"
+    assert ast.collection.name == "machine-hazards"
+    assert isinstance(ast.condition, ConditionNode)
+
+
+def test_parses_compound_condition_with_explicit_binding():
+    ast = _parse(
+        "require each item in items is above 5 and item is below 100"
+    )
+    assert isinstance(ast, RequireEachNode)
+    assert isinstance(ast.condition, CompoundConditionNode)
+    assert ast.condition.connector == "and"
+    # First branch elides its field (EachPronoun); second names the binding.
+    assert isinstance(ast.condition.left.field, EachPronoun)
+    assert isinstance(ast.condition.right.field, NameRef)
+    assert ast.condition.right.field.name == "item"
+
+
+def test_parses_not_operator():
+    ast = _parse('require each value in values is not equal to "invalid"')
+    assert isinstance(ast, RequireEachNode)
+    assert ast.condition.op == "not_equal_to"
+
+
+def test_parses_includes_operator():
+    ast = _parse('require each tag-list in all-tag-lists includes "required"')
+    assert isinstance(ast, RequireEachNode)
+    assert ast.condition.op == "includes"
+
+
+def test_parses_within_operator():
+    ast = _parse("require each reading in readings is within 5 of baseline")
+    assert isinstance(ast, RequireEachNode)
+    assert ast.condition.op == "within"
+
+
+def test_error_missing_in():
+    r = _parse("require each score scores is above 70")
+    assert isinstance(r, LiminateResult)
+    assert r.status is ResultStatus.ERROR_PARSE
+    assert "in" in (r.message or "")
+
+
+def test_error_missing_condition():
+    r = _parse("require each score in scores")
+    assert isinstance(r, LiminateResult)
+    assert r.status is ResultStatus.ERROR_PARSE
+    assert "condition" in (r.message or "")
+
+
+def test_error_reserved_word_as_binding():
+    r = _parse("require each filter in items is above 5")
+    assert isinstance(r, LiminateResult)
+    assert r.status is ResultStatus.ERROR_PARSE
+    assert "reserved" in (r.message or "")
+
+
+# ---------------------------------------------------------------------------
+# Integration — scalar lists
+# ---------------------------------------------------------------------------
+
+
+def test_all_pass_scalar_list():
+    s = _session()
+    s.run_line("remember a list called scores with 80 and 90 and 75")
+    r = s.run_line("require each score in scores is above 70")
+    assert r.status is ResultStatus.SUCCESS
+    assert r.output is None
+
+
+def test_one_fails_scalar_list_identifies_element():
+    s = _session()
+    s.run_line("remember a list called scores with 80 and 60 and 75")
+    r = s.run_line("require each score in scores is above 70")
+    assert r.status is ResultStatus.REQUIREMENT_NOT_MET
+    assert "Requirement not met" in (r.message or "")
+    assert "element 2" in (r.message or "")
+
+
+# ---------------------------------------------------------------------------
+# Integration — record lists
+# ---------------------------------------------------------------------------
+
+
+def _seed_records(s: Session, second_status: str) -> None:
+    s.run_line("remember a record called alpha with name as a1 and status as active")
+    s.run_line(
+        f"remember a record called beta with name as b1 and status as {second_status}"
+    )
+    s.run_line("remember a list called items with alpha and beta")
+
+
+def test_all_pass_record_list():
+    s = _session()
+    _seed_records(s, "active")
+    r = s.run_line('require each item in items status is equal to "active"')
+    assert r.status is ResultStatus.SUCCESS
+
+
+def test_one_fails_record_list():
+    s = _session()
+    _seed_records(s, "inactive")
+    r = s.run_line('require each item in items status is equal to "active"')
+    assert r.status is ResultStatus.REQUIREMENT_NOT_MET
+    assert "element 2" in (r.message or "")
+
+
+# ---------------------------------------------------------------------------
+# Integration — compound conditions
+# ---------------------------------------------------------------------------
+
+
+def test_compound_all_pass():
+    s = _session()
+    s.run_line("remember a list called values with 5 and 50 and 99")
+    r = s.run_line(
+        "require each val in values is above 0 and val is below 100"
+    )
+    assert r.status is ResultStatus.SUCCESS
+
+
+def test_compound_one_fails():
+    s = _session()
+    s.run_line("remember a list called values with 5 and 150 and 99")
+    r = s.run_line(
+        "require each val in values is above 0 and val is below 100"
+    )
+    assert r.status is ResultStatus.REQUIREMENT_NOT_MET
+    assert "element 2" in (r.message or "")
+
+
+# ---------------------------------------------------------------------------
+# Integration — edge cases & binding hygiene
+# ---------------------------------------------------------------------------
+
+
+def test_empty_list_is_vacuously_true():
+    s = _session()
+    # Build an empty list by filtering everything out.
+    s.run_line("remember a list called nums with 1 and 2 and 3")
+    s.run_line("filter nums where each is above 100")
+    r = s.run_line("require each item in nums is above 0")
+    assert r.status is ResultStatus.SUCCESS
+
+
+def test_binding_does_not_leak():
+    s = _session()
+    s.run_line("remember a list called scores with 80 and 90 and 75")
+    r = s.run_line("require each score in scores is above 70")
+    assert r.status is ResultStatus.SUCCESS
+    assert "score" not in s.symtab
+
+
+def test_binding_restores_shadowed_name():
+    s = _session()
+    s.run_line("remember a value called score with 999")
+    s.run_line("remember a list called scores with 80 and 90 and 75")
+    r = s.run_line("require each score in scores is above 70")
+    assert r.status is ResultStatus.SUCCESS
+    assert s.symtab["score"].value == 999
+
+
+def test_error_binding_name_equals_collection_name():
+    s = _session()
+    s.run_line("remember a list called scores with 80 and 90")
+    r = s.run_line("require each scores in scores is above 70")
+    assert r.status is ResultStatus.ERROR_SEMANTIC
+    assert "same as the list name" in (r.message or "")
+
+
+def test_works_inside_then_sequence():
+    s = _session()
+    r = s.run_line(
+        "remember a list called nums with 1 and 2 and 3 "
+        "then require each n in nums is above 0"
+    )
+    assert r.status is ResultStatus.SUCCESS
+
+
+# ---------------------------------------------------------------------------
+# Metadata modifiers
+# ---------------------------------------------------------------------------
+
+
+def test_because_rationale_preserved():
+    ast = _parse(
+        'require each score in scores is above 70 '
+        'because "minimum passing grade"'
+    )
+    assert isinstance(ast, RequireEachNode)
+    assert ast.rationale == "minimum passing grade"
+    assert 'because "minimum passing grade"' in render(ast)
+
+
+def test_inherited_modifier():
+    ast = _parse("inherited require each score in scores is above 70")
+    assert isinstance(ast, RequireEachNode)
+    assert ast.inherited is True
+    assert render(ast).startswith("inherited ")
+
+
+def test_starting_until_modifiers():
+    ast = _parse(
+        'starting "2025-07-01" until "2025-12-31" '
+        "require each score in scores is above 70"
+    )
+    assert isinstance(ast, RequireEachNode)
+    assert ast.starting_date == "2025-07-01"
+    assert ast.until_date == "2025-12-31"
+
+
+def test_mixed_and_or_triggers_amber():
+    r = _parse(
+        "require each item in items is above 5 and item is below 100 "
+        "or item is equal to 0"
+    )
+    assert isinstance(r, LiminateResult)
+    assert r.status is ResultStatus.AMBER_PRECEDENCE
+
+
+# ---------------------------------------------------------------------------
+# Round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_render_round_trip_is_stable():
+    ast = _parse("require each score in scores is above 70")
+    canonical = render(ast)
+    again = _parse(canonical)
+    assert isinstance(again, RequireEachNode)
+    assert render(again) == canonical
+
+
+def test_render_round_trip_compound():
+    ast = _parse(
+        "require each item in items is above 5 and item is below 100"
+    )
+    canonical = render(ast)
+    again = _parse(canonical)
+    assert isinstance(again, RequireEachNode)
+    assert render(again) == canonical
+
+
+# ---------------------------------------------------------------------------
+# Regression guards (§8 invariants 2 & 3)
+# ---------------------------------------------------------------------------
+
+
+def test_existing_require_unchanged():
+    ast = _parse("require total is above 100")
+    assert isinstance(ast, RequireNode)
+    assert not isinstance(ast, RequireEachNode)
+    assert ast.condition.op == "above"
+
+
+def test_each_standalone_verb_unchanged():
+    s = _session()
+    s.run_line("remember a list called scores with 1 and 2")
+    r = s.run_line("each scores show")
+    assert r.status is ResultStatus.SUCCESS
+
+
+def test_each_pronoun_in_where_unchanged():
+    s = _session()
+    s.run_line("remember a list called scores with 40 and 60")
+    r = s.run_line("filter the scores where each is above 50")
+    assert r.status is ResultStatus.SUCCESS


### PR DESCRIPTION
## Specification source
v8a §49 (EXP-Q1 resolution)

## What
A second parse shape for `require`:

```
require each {name} in {list} {condition}
```

Evaluates `{condition}` once per element in `{list}`, with `{name}` bound to the current element. Halts with `REQUIREMENT_NOT_MET` on the first failing element (identified, 1-indexed); silent if all elements pass.

```
require each score in scores is above 70
require each item in items status is equal to "active"
require each val in values is above 0 and val is below 100
```

## Changes
- **New AST node** `RequireEachNode` (not an overloaded `RequireNode`)
- **parser.py** — `_parse_require` lookahead for `each`; new `_parse_require_each`; `_contains_mixed_precedence` branch
- **analyzer.py** — `_check_require_each`: collection-is-a-list + binding ≠ collection-name; `IteratorContext.binding_name` resolution
- **interpreter.py** — `_exec_require_each` with save/restore binding hygiene
- **renderer.py** — canonical rendering case
- **tests/test_require_each.py** — new, 29 tests

## Notable design point
The spec example `require each score in scores is above 70` has an **elided condition field** — `is above 70` has no LHS, since `score` is consumed as the binding. The existing condition parser requires an explicit field, and the spec's "no condition-grammar change" was contradictory here. Resolved by injecting an implicit `EachPronoun` for field-elided conditions, **scoped to a `require-each` clause context** so `where`/`choose`/plain-`require` grammar is untouched. Explicit binding-name references (`item is below 100`) resolve via a temporary symbol-table entry, exactly as §5 describes. Consequence: canonical rendering makes the elided field explicit (`... each is above 70`); round-trip is stable (tested).

## No vocabulary change
The 58 base reserved words are unchanged. `vocabulary.py` is not modified. `in` remains an UNKNOWN token consumed positionally.

## Test count
Baseline 1303 → **1332 passing** (+29 new). Zero regressions.

## Consistency invariants (§8)
All satisfied: 58 words unchanged · existing `require` tests unchanged · existing `each` verb/pronoun tests unchanged · standard metadata fields (`rationale`/`inherited`/`inherited_from`/`starting_date`/`until_date`) via the existing `_parse_one_operation` chokepoint · binding always cleaned up via `finally` · canonical rendering round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)