### PR TITLE
feat: run() enter_phase2 control + per-result line/source metadata (v0.11.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liminate"
-version = "0.10.0"
+version = "0.11.0"
 description = "A prose-as-syntax programming language designed from the human end."
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/src/liminate/result.py
+++ b/src/liminate/result.py
@@ -69,3 +69,11 @@ class LiminateResult:
     #                   ...}
     # None for Phase 1 results (v2d-identical contract preserved).
     metadata: dict | None = None
+    # Source position, set by `run.run()` so embedders (e.g. Receipts'
+    # serialize_result) can attribute each result to its source line without
+    # re-running the loop. `line` is the 1-based source line; `source` is the
+    # raw source line text. None for results not produced by `run()` (e.g. a
+    # bare `execute()` call). Excluded from equality/repr so they stay
+    # non-behavioral metadata and don't affect result comparisons in tests.
+    line: int | None = field(default=None, compare=False, repr=False)
+    source: str | None = field(default=None, compare=False, repr=False)

--- a/src/liminate/run.py
+++ b/src/liminate/run.py
@@ -371,6 +371,10 @@ def _consume_when_block(
             executed=False,
         )
         ts = datetime.now(timezone.utc).isoformat()
+        err.line = start_idx + 1
+        err.source = header_line
+        err.timestamp = ts
+        err.duration_ms = 0.0
         emit(err, start_idx + 1, ts, 0.0)
         return next_index
 
@@ -381,6 +385,8 @@ def _consume_when_block(
     if result is not None:
         result.timestamp = ts
         result.duration_ms = dur
+        result.line = start_idx + 1
+        result.source = header_line
     emit(result, start_idx + 1, ts, dur)
     return next_index
 
@@ -395,6 +401,7 @@ def run(
     *,
     domain_packs: list[DomainPack] | None = None,
     auto_confirm_amber: bool = False,
+    enter_phase2: bool = True,
     on_result: ResultSink | None = None,
     on_blank: Callable[[], None] | None = None,
 ) -> ContractResult:
@@ -412,6 +419,14 @@ def run(
       mirroring the historic `--test` / runner `_confirm_amber` behavior —
       with no `input()` call. When False, amber results are left in
       `results` unresolved for the caller to handle.
+    - `enter_phase2`: when True (default — the CLI's behavior), the
+      event-driven listener runs after Phase 1 if any `when` handler
+      registered and Phase 1 had no errors. When False, Phase 2 is skipped
+      entirely: handlers are still registered during Phase 1 (so the
+      registration result appears in `results`) but never fire, and no
+      LISTENING/HANDLER_FIRE/SHUTDOWN results are produced. Static
+      inspectors (e.g. Receipts) that treat a contract as text — not a live
+      reactive program — pass `enter_phase2=False`.
     - `on_result`: optional per-result sink (the CLI passes a closure that
       calls `display_result`). When supplied, amber confirmation and
       blank-line rendering are the sink's responsibility (it runs inline at
@@ -419,6 +434,10 @@ def run(
       amber itself in that case.
     - `on_blank`: optional callback invoked for each blank/comment line
       skipped at top level (CLI uses it for quiet-mode blank mirroring).
+
+    Each produced `LiminateResult` carries `line` (1-based source line) and
+    `source` (raw line text) so embedders can serialize per-line without
+    re-running the loop.
     """
     session = Session(domain_packs=domain_packs)
     results: list[LiminateResult] = []
@@ -435,15 +454,13 @@ def run(
         dur: float | None,
     ) -> None:
         """Single funnel for every produced result (Phase 1 + Phase 2)."""
-        if result is not None:
-            results.append(result)
-        if on_result is not None:
-            on_result(result, session, line_num, ts, dur)
-        session.record_result(result)
-        # Embedder mode (no display sink): resolve amber non-interactively
-        # so the returned `results` reflect confirmation. With a sink, the
-        # sink (display_result) already resolves amber inline — resolving
-        # here too would double-execute the pending AST.
+        # Embedder mode (no display sink): resolve amber non-interactively so
+        # the returned `results` reflect confirmation, *replacing* the amber
+        # result with its executed form — matching the historic runner
+        # `_confirm_amber` semantics (one result per line, not two). The
+        # source-position/timing metadata carries onto the resolved result.
+        # With a display sink, the sink (display_result) resolves amber inline
+        # instead — resolving here too would double-execute the pending AST.
         if (
             on_result is None
             and auto_confirm_amber
@@ -452,8 +469,16 @@ def run(
             and result.pending_ast is not None
         ):
             resolved = execute(result.pending_ast, session.symtab)
-            results.append(resolved)
-            session.record_result(resolved)
+            resolved.line = result.line
+            resolved.source = result.source
+            resolved.timestamp = result.timestamp
+            resolved.duration_ms = result.duration_ms
+            result = resolved
+        if result is not None:
+            results.append(result)
+        if on_result is not None:
+            on_result(result, session, line_num, ts, dur)
+        session.record_result(result)
 
     lines = source.splitlines()
 
@@ -511,6 +536,10 @@ def run(
             first_eligible_seen = True
             if err is not None:
                 ts = datetime.now(timezone.utc).isoformat()
+                err.line = i + 1
+                err.source = line
+                err.timestamp = ts
+                err.duration_ms = 0.0
                 _emit(err, i + 1, ts, 0.0)
             i += 1
             continue
@@ -527,6 +556,10 @@ def run(
                 executed=False,
             )
             ts = datetime.now(timezone.utc).isoformat()
+            err.line = i + 1
+            err.source = line
+            err.timestamp = ts
+            err.duration_ms = 0.0
             _emit(err, i + 1, ts, 0.0)
             i += 1
             continue
@@ -564,14 +597,20 @@ def run(
         if result is not None:
             result.timestamp = ts
             result.duration_ms = dur
+            result.line = i + 1
+            result.source = line
         _emit(result, i + 1, ts, dur)
         i += 1
 
-    # v3a §107 — Phase 2 gate: only enter listener mode if Phase 1 had
-    # zero errors AND at least one handler registered. Otherwise the
-    # source executed as a regular v2d program (or reported Phase 1
-    # errors that the user must fix before listening can begin).
-    if session.handler_table.is_empty() or session.phase1_had_error:
+    # v3a §107 — Phase 2 gate: only enter listener mode if the caller opted
+    # in (enter_phase2), Phase 1 had zero errors, AND at least one handler
+    # registered. Otherwise the source executed as a regular v2d program (or
+    # the caller — e.g. a static inspector — asked to stop after Phase 1).
+    if (
+        not enter_phase2
+        or session.handler_table.is_empty()
+        or session.phase1_had_error
+    ):
         return ContractResult(
             results=results,
             symbol_table=session.symtab,


### PR DESCRIPTION
## Why

Follow-up to #38 (public `liminate.run()`). PR 2 in liminate-receipts collapses `runner.run_contract` onto `run()`, but two gaps surfaced that — per the build spec — must be fixed **in `run()`**, never by re-adding a loop in Receipts:

1. **Phase-2 divergence.** `runner.run_contract` is deliberately *Phase-1-only* (it registers `when` handlers and stops). `run()` enters Phase 2 whenever handlers register, which on a typical session contract (full of `when` blocks) adds `LISTENING`/`HANDLER_FIRE`/`SHUTDOWN` results and *executes handler bodies* — diverging both the result stream and the symbol table.
2. **Per-line metadata.** `serialize_result(line_num, source_line, …)` needs each result's source position; `ContractResult.results` exposed neither.

## Changes

- **`enter_phase2: bool = True`** on `run()`. Default preserves the CLI's behavior. `enter_phase2=False` skips the Phase-2 listener entirely — handlers still register in Phase 1 (so the registration result appears in `results`) but never fire. Static inspectors pass `False`.
- **`LiminateResult.line` / `.source`** — the 1-based source line and raw line text, set by `run()` on every produced result. Both are `field(compare=False, repr=False)` so they're non-behavioral metadata and don't affect result equality (no test churn).
- **Embedder amber path** now *replaces* an amber result with its resolved (executed) form — matching the historic `runner._confirm_amber` (one result per line, not two) — carrying source/timing onto the resolved result.
- **Version 0.10.0 → 0.11.0.**

## Verification

- **1339 tests pass** (baseline; zero test-file edits).
- **Byte-identical CLI gate** (PR #38's corpus) still holds — `enter_phase2` defaults True, new fields excluded from equality/display.
- **End-to-end cross-check**: `run(source, enter_phase2=False, auto_confirm_amber=True)` fed through Receipts' `serialize_result`/`serialize_symtab` is **identical (modulo timestamps)** to the current `runner.run_contract` across a corpus (template-like with `when`, `about`+`cite`, error-line) — same result counts, topics, and full serialized JSON.

## After merge

Publish **liminate 0.11.0 to PyPI** (the `release.yml` workflow builds binaries only; the PyPI upload is a manual `twine` step needing the token). Then liminate-receipts PR 2 collapses `runner.run_contract` onto `run(..., enter_phase2=False)` and bumps its pin to `liminate==0.11.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)