### PR TITLE
docs: retarget Receipts host to liminate.dev in VERSIONING

### DIFF
--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -34,7 +34,7 @@ liminate==0.10.0
 dependencies = ["liminate==0.10.0"]
 ```
 
-The Receipts server at `receipts.liminate.dev` pins its interpreter dependency and records `liminate_version` and `pack_version` on every saved contract. These values are the replay coordinates — given the same versions and the same source, the result is identical.
+The Receipts server at `liminate.dev` pins its interpreter dependency and records `liminate_version` and `pack_version` on every saved contract. These values are the replay coordinates — given the same versions and the same source, the result is identical.
 
 ## Session pack versioning
 


### PR DESCRIPTION
Receipts was consolidated from the `receipts.liminate.dev` subdomain onto the apex **`liminate.dev`** (single deployment per the `liminate-dev` backend). `docs/VERSIONING.md` referenced the dead subdomain for the Receipts server's version-pinning behavior; retargeted to `liminate.dev`.

Part of a small cross-repo sweep of the rename (`liminate-site` is archived and excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)