### PR TITLE
v0.12.0: Pack verb failure status, inherited when propagation, structured failure identity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liminate"
-version = "0.11.0"
+version = "0.12.0"
 description = "A prose-as-syntax programming language designed from the human end."
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/src/liminate/build.py
+++ b/src/liminate/build.py
@@ -200,6 +200,18 @@ def _validate_and_render(source: str) -> tuple[list[str], list[Any], str | None]
                 and header_tokens[0].value == "when"
             ):
                 is_when_header = True
+            # Meta-Structural Era batch 3 — detect `inherited when` so
+            # `liminate build` accepts every program `liminate run` does
+            # (§7 invariant 4). Detection mirrors run.py exactly.
+            elif (
+                header_tokens
+                and header_tokens[0].type is TokenType.OPERATOR
+                and header_tokens[0].value == "inherited"
+                and len(header_tokens) > 1
+                and header_tokens[1].type is TokenType.CONNECTIVE
+                and header_tokens[1].value == "when"
+            ):
+                is_when_header = True
 
         if is_when_header:
             action_lines, next_i = _collect_when_block(lines, i)

--- a/src/liminate/interpreter.py
+++ b/src/liminate/interpreter.py
@@ -357,19 +357,39 @@ class _RequirementNotMet(Exception):
     evaluates false. Surfaced to callers as REQUIREMENT_NOT_MET. The
     exception unwinds through nested sequences, compositions, and
     `choose` branches so prior committed operations stay committed
-    under stepwise semantics (v1d §56)."""
-    def __init__(self, message: str):
+    under stepwise semantics (v1d §56).
+
+    Invariant-readiness: carries optional structured `failure_metadata`
+    (verb, condition, actual values) for machine-readable failure
+    identity on the surfaced result."""
+    def __init__(self, message: str, metadata: dict | None = None):
         super().__init__(message)
         self.message = message
+        self.failure_metadata = metadata or {}
 
 
 class _ProhibitionViolated(Exception):
     """Deontic Era — raised when a `forbid` condition evaluates true.
     Surfaced to callers as PROHIBITION_VIOLATED. Same unwind semantics
-    as _RequirementNotMet: stepwise operations stay committed."""
-    def __init__(self, message: str):
+    as _RequirementNotMet: stepwise operations stay committed.
+
+    Invariant-readiness: carries optional structured `failure_metadata`
+    (verb, condition, actual values) for machine-readable failure
+    identity on the surfaced result."""
+    def __init__(self, message: str, metadata: dict | None = None):
         super().__init__(message)
         self.message = message
+        self.failure_metadata = metadata or {}
+
+
+class _PackVerbFailure(Exception):
+    """Raised when a pack verb's verification check finds a mismatch.
+    Surfaced as PACK_VERB_FAILURE. Carries structured metadata for
+    machine-readable failure identity."""
+    def __init__(self, message: str, metadata: dict):
+        super().__init__(message)
+        self.message = message
+        self.failure_metadata = metadata
 
 
 def _execute_single(
@@ -402,19 +422,39 @@ def _execute_single(
             executed=False,
         )
     except _RequirementNotMet as e:
-        return LiminateResult(
+        result = LiminateResult(
             status=ResultStatus.REQUIREMENT_NOT_MET,
             canonical=render(node),
             message=e.message,
             executed=False,
         )
+        if e.failure_metadata:
+            result.metadata = e.failure_metadata
+        return result
     except _ProhibitionViolated as e:
-        return LiminateResult(
+        result = LiminateResult(
             status=ResultStatus.PROHIBITION_VIOLATED,
             canonical=render(node),
             message=e.message,
             executed=False,
         )
+        if e.failure_metadata:
+            result.metadata = e.failure_metadata
+        return result
+    except _PackVerbFailure as e:
+        result = LiminateResult(
+            status=ResultStatus.PACK_VERB_FAILURE,
+            canonical=render(node),
+            message=e.message,
+            executed=False,
+        )
+        result.metadata = e.failure_metadata
+        # Preserve pack attribution (Receipts v5 §15 dim. 3).
+        if isinstance(node, PackVerbNode):
+            owner = get_pack_verb_owner(node.word)
+            if owner is not None:
+                result.metadata["pack"] = owner
+        return result
     _mark_live_value_active_if_remember(node, live_value_registry)
     result = LiminateResult(
         status=ResultStatus.SUCCESS,
@@ -463,26 +503,37 @@ def _execute_sequence(
                 seq,
             )
         except _RequirementNotMet as e:
+            fail_result = LiminateResult(
+                status=ResultStatus.REQUIREMENT_NOT_MET,
+                message=e.message,
+            )
+            if e.failure_metadata:
+                fail_result.metadata = e.failure_metadata
             return _stepwise_error(
-                op,
-                LiminateResult(
-                    status=ResultStatus.REQUIREMENT_NOT_MET,
-                    message=e.message,
-                ),
-                completed_canonicals,
-                outputs,
-                seq,
+                op, fail_result, completed_canonicals, outputs, seq,
             )
         except _ProhibitionViolated as e:
+            fail_result = LiminateResult(
+                status=ResultStatus.PROHIBITION_VIOLATED,
+                message=e.message,
+            )
+            if e.failure_metadata:
+                fail_result.metadata = e.failure_metadata
             return _stepwise_error(
-                op,
-                LiminateResult(
-                    status=ResultStatus.PROHIBITION_VIOLATED,
-                    message=e.message,
-                ),
-                completed_canonicals,
-                outputs,
-                seq,
+                op, fail_result, completed_canonicals, outputs, seq,
+            )
+        except _PackVerbFailure as e:
+            fail_result = LiminateResult(
+                status=ResultStatus.PACK_VERB_FAILURE,
+                message=e.message,
+            )
+            fail_result.metadata = e.failure_metadata
+            if isinstance(op, PackVerbNode):
+                owner = get_pack_verb_owner(op.word)
+                if owner is not None:
+                    fail_result.metadata["pack"] = owner
+            return _stepwise_error(
+                op, fail_result, completed_canonicals, outputs, seq,
             )
         _mark_live_value_active_if_remember(op, live_value_registry)
         completed_canonicals.append(render(op))
@@ -541,13 +592,20 @@ def _stepwise_error(
             msg += " The filter has already been applied."
     else:
         msg = failure.message
-    return LiminateResult(
+    result = LiminateResult(
         status=failure.status,
         canonical=render(seq),
         output=outputs if outputs else None,
         message=msg,
         executed=False,
     )
+    # Invariant-readiness: carry the structured failure identity
+    # (verb / condition / actual / pack) through the stepwise wrapper so
+    # downstream consumers see the same metadata on a sequence failure as
+    # on a single-statement failure.
+    if failure.metadata:
+        result.metadata = failure.metadata
+    return result
 
 
 def _is_filter_canonical(canonical: str) -> bool:
@@ -810,9 +868,15 @@ def _exec_pack_substring_check(
         )
         preview = against_value[:80]
         suffix = "..." if len(against_value) > 80 else ""
-        raise _RuntimeError(
+        raise _PackVerbFailure(
             f"The text '{check_value}' was not found in '{against_name}'. "
-            f"The source begins: '{preview}{suffix}'"
+            f"The source begins: '{preview}{suffix}'",
+            metadata={
+                "verb": node.word,
+                "failure_type": "substring_not_found",
+                "check_value": check_value,
+                "against_name": against_name,
+            },
         )
     return []
 
@@ -913,37 +977,28 @@ def _exec_pack_compare_values(
             status = "type_mismatch"
             details = []
 
+    # Symbol table writes stay for handler visibility — a `when` handler
+    # watching `verification-status`/`verification-divergences` needs the
+    # value committed before the failure exception unwinds (§8 mode 1).
     _store(symtab, execution.status_target, status)
     if execution.details_target is not None:
         _store(symtab, execution.details_target, list(details))
 
-    if execution.on_mismatch == "error" and status != "match":
-        if execution.comparison == "equality":
-            raise _RuntimeError(
-                f"'{left_name}' does not match '{right_name}'."
-            )
-        if status == "length_mismatch":
-            raise _RuntimeError(
-                f"'{left_name}' and '{right_name}' have different lengths."
-            )
-        if status == "type_mismatch":
-            raise _RuntimeError(
-                f"'{left_name}' and '{right_name}' have different shapes."
-            )
-        if details and all(isinstance(d, str) for d in details):
-            fields_str = ", ".join(f"'{d}'" for d in details)
-            raise _RuntimeError(
-                f"'{left_name}' and '{right_name}' diverge on fields: "
-                f"{fields_str}."
-            )
-        if details:
-            idx_str = ", ".join(str(d) for d in details)
-            raise _RuntimeError(
-                f"'{left_name}' and '{right_name}' differ at positions: "
-                f"{idx_str}."
-            )
-        raise _RuntimeError(
-            f"'{left_name}' does not match '{right_name}'."
+    # Invariant-readiness: any non-match outcome surfaces as
+    # PACK_VERB_FAILURE, regardless of the pack's on_mismatch mode. This
+    # subsumes the former on_mismatch == "error" raise block — the result
+    # stream, not the symbol table, is now the source of truth for failure.
+    if status != "match":
+        raise _PackVerbFailure(
+            f"'{left_name}' does not match '{right_name}'. Status: {status}.",
+            metadata={
+                "verb": node.word,
+                "failure_type": f"comparison_{status}",
+                "left_name": left_name,
+                "right_name": right_name,
+                "status": status,
+                "divergences": list(details) if details else [],
+            },
         )
     return []
 
@@ -977,14 +1032,18 @@ def _exec_pack_numeric_extract_compare(
             against_node.name if isinstance(against_node, NameRef)
             else execution.against_slot
         )
-        if execution.on_mismatch == "error":
-            raise _RuntimeError(
-                f"No numbers found in '{against_name}'."
-            )
+        # Symbol table writes stay for handler visibility before the raise.
         _store(symtab, execution.status_target, "no_numbers_found")
         _store(symtab, execution.matched_target, "none")
         _store(symtab, execution.delta_target, "none")
-        return []
+        raise _PackVerbFailure(
+            f"No numbers found in '{against_name}'.",
+            metadata={
+                "verb": node.word,
+                "failure_type": "no_numbers_found",
+                "against_name": against_name,
+            },
+        )
 
     closest = min(numbers, key=lambda n: abs(n - claimed))
     delta = abs(claimed - closest)
@@ -1000,16 +1059,27 @@ def _exec_pack_numeric_extract_compare(
     _store(symtab, execution.matched_target, closest)
     _store(symtab, execution.delta_target, delta)
 
-    if not within and execution.on_mismatch == "error":
+    # Invariant-readiness: outside-tolerance surfaces as PACK_VERB_FAILURE
+    # regardless of on_mismatch mode. Writes above stay committed.
+    if not within:
         against_name = (
             against_node.name if isinstance(against_node, NameRef)
             else execution.against_slot
         )
-        raise _RuntimeError(
+        raise _PackVerbFailure(
             f"Claimed {_format_scalar(claimed)} but closest value in "
             f"'{against_name}' is {_format_scalar(closest)} "
             f"(delta: {_format_scalar(delta)}, tolerance: "
-            f"{_format_scalar(tolerance)})."
+            f"{_format_scalar(tolerance)}).",
+            metadata={
+                "verb": node.word,
+                "failure_type": "outside_tolerance",
+                "claimed": claimed,
+                "closest": closest,
+                "delta": delta,
+                "tolerance": tolerance,
+                "against_name": against_name,
+            },
         )
     return []
 
@@ -1382,7 +1452,11 @@ def _exec_require(
     msg = f"Requirement not met: {condition_text}."
     if actual:
         msg += f" {actual}"
-    raise _RequirementNotMet(msg)
+    raise _RequirementNotMet(msg, metadata={
+        "verb": "require",
+        "condition": condition_text,
+        "actual": actual,
+    })
 
 
 def _exec_require_each(
@@ -1424,7 +1498,15 @@ def _exec_require_each(
                 )
                 if actual:
                     msg += f" {actual}"
-                raise _RequirementNotMet(msg)
+                raise _RequirementNotMet(msg, metadata={
+                    "verb": "require",
+                    "iteration": "each",
+                    "binding": node.binding_name,
+                    "collection": node.collection.name,
+                    "element_index": i,
+                    "condition": condition_text,
+                    "actual": actual,
+                })
     finally:
         if saved is not None:
             symtab[node.binding_name] = saved
@@ -1451,7 +1533,11 @@ def _exec_forbid(
     msg = f"Prohibition violated: {condition_text}."
     if actual:
         msg += f" {actual}"
-    raise _ProhibitionViolated(msg)
+    raise _ProhibitionViolated(msg, metadata={
+        "verb": "forbid",
+        "condition": condition_text,
+        "actual": actual,
+    })
 
 
 def _exec_permit(

--- a/src/liminate/listener.py
+++ b/src/liminate/listener.py
@@ -42,6 +42,7 @@ from .interpreter import (
     HandlerTable,
     _exec_op,
     _FinishRequested,
+    _PackVerbFailure,
     _RequirementNotMet,
     _RuntimeError,
     _in_action_block,
@@ -443,6 +444,24 @@ class _Runner:
                     source, handler, values_changed, new_values,
                 )
                 continue
+            except _PackVerbFailure as e:
+                # Invariant-readiness — a pack verb (cite/verify/measure)
+                # inside an action block failed its check. Report on this
+                # statement and continue with the rest of the block; the
+                # structured failure_metadata is preserved alongside the
+                # trigger envelope by _wrap_with_trigger.
+                fail_result = LiminateResult(
+                    status=ResultStatus.PACK_VERB_FAILURE,
+                    canonical=render(stmt),
+                    message=e.message,
+                    executed=False,
+                )
+                fail_result.metadata = e.failure_metadata
+                yield self._wrap_with_trigger(
+                    fail_result,
+                    source, handler, values_changed, new_values,
+                )
+                continue
 
             # §122 — successful action statements are HANDLER_FIRE.
             yield self._wrap_with_trigger(
@@ -583,14 +602,23 @@ class _Runner:
         """v3a §122 — attach the trigger envelope to an action-statement
         result. Successful results were already created with
         HANDLER_FIRE status; error results keep their original status."""
-        base.metadata = {
-            "trigger": {
-                "source": source,
-                "handler_index": handler.index,
-                "values_changed": list(values_changed),
-                "new_values": dict(new_values),
-            },
+        trigger_meta = {
+            "source": source,
+            "handler_index": handler.index,
+            "values_changed": list(values_changed),
+            "new_values": dict(new_values),
         }
+        # Meta-Structural Era batch 3 — propagate inherited provenance from
+        # the WhenNode to the HANDLER_FIRE metadata so downstream consumers
+        # (Invariant) can distinguish pre-flight checklist handlers from
+        # session-authored handlers.
+        if handler.when_node.inherited:
+            trigger_meta["inherited"] = True
+            if handler.when_node.inherited_from is not None:
+                trigger_meta["inherited_from"] = handler.when_node.inherited_from
+        # Merge rather than clobber (§8 mode 2): a failure result may already
+        # carry structured failure_metadata that must survive the wrap.
+        base.metadata = {**(base.metadata or {}), "trigger": trigger_meta}
         return base
 
     def _cycle_error(

--- a/src/liminate/parser.py
+++ b/src/liminate/parser.py
@@ -490,6 +490,14 @@ class WhenNode(ASTNode):
     condition: ASTNode
     unless: ASTNode | None
     action: ASTNode
+    # Meta-Structural Era batch 3 — `inherited` operator + `from`
+    # attribution, extended to `when` blocks. Inert provenance metadata
+    # (compare=False). When a `when` handler is marked `inherited`, its
+    # HANDLER_FIRE results carry the flag in their trigger metadata so
+    # downstream consumers (Invariant) can distinguish pre-flight
+    # checklist handlers from session-authored handlers.
+    inherited: bool = field(default=False, compare=False)
+    inherited_from: str | None = field(default=None, compare=False)
 
 
 @dataclass
@@ -1101,6 +1109,27 @@ def parse_when_block(
             executed=False,
         )
 
+    # Meta-Structural Era batch 3 — `inherited when` support. A
+    # statement-initial `inherited` operator precedes the `when`
+    # connective; strip it here and flag the resulting WhenNode so the
+    # rest of the header parses exactly as a plain `when` block.
+    is_inherited = False
+    if (
+        header_tokens[0].type is TokenType.OPERATOR
+        and header_tokens[0].value == "inherited"
+    ):
+        is_inherited = True
+        header_tokens = header_tokens[1:]
+
+    if not header_tokens:
+        return LiminateResult(
+            status=ResultStatus.ERROR_PARSE,
+            message=(
+                "'inherited' must be followed by a 'when' statement here."
+            ),
+            executed=False,
+        )
+
     if not (
         header_tokens[0].type is TokenType.CONNECTIVE
         and header_tokens[0].value == "when"
@@ -1189,6 +1218,14 @@ def parse_when_block(
     )
 
     when_node = WhenNode(condition=condition, unless=unless_guard, action=action)
+    if is_inherited:
+        when_node.inherited = True
+        # Agent attribution (`from <agent>`) on `inherited when` blocks is
+        # deferred: a trailing `from` on a `when` header belongs to
+        # condition slot resolution (e.g. `cite "x" from source`), not
+        # attribution. The `inherited` flag alone is sufficient for
+        # Invariant; `inherited_from` on `when` awaits a designed grammar.
+        when_node.inherited_from = None
 
     # v3a §123: condition or guard mixed and/or — amber. Action sub-
     # statements were already amber-checked individually by `parse()`,

--- a/src/liminate/result.py
+++ b/src/liminate/result.py
@@ -43,6 +43,14 @@ class ResultStatus(Enum):
     # The deontic triple: require (obligation), forbid (prohibition),
     # permit (permission).
     PERMITTED = "permitted"
+    # Invariant-readiness: a pack verb's verification check found a
+    # mismatch. Distinct from ERROR_SEMANTIC ("the program has a bug")
+    # — PACK_VERB_FAILURE means "the data did not satisfy the verb's
+    # check." Covers cite (substring not found), verify (structural
+    # mismatch), and measure (outside tolerance). The result's metadata
+    # carries the pack name, verb, failure type, and slot values for
+    # machine-readable failure identity.
+    PACK_VERB_FAILURE = "pack_verb_failure"
 
 
 @dataclass

--- a/src/liminate/run.py
+++ b/src/liminate/run.py
@@ -217,12 +217,14 @@ class Session:
             ResultStatus.ERROR_SEMANTIC,
             ResultStatus.AMBER_PRECEDENCE,
             ResultStatus.AMBER_AMBIGUITY,
+            ResultStatus.PACK_VERB_FAILURE,
         ):
             self.phase1_had_error = True
         if result.status in (
             ResultStatus.ERROR_PARSE,
             ResultStatus.ERROR_SEMANTIC,
             ResultStatus.ERROR_RUNTIME,
+            ResultStatus.PACK_VERB_FAILURE,
         ):
             self.had_any_error = True
 
@@ -578,6 +580,18 @@ def run(
                 header_tokens
                 and header_tokens[0].type is TokenType.CONNECTIVE
                 and header_tokens[0].value == "when"
+            ):
+                is_when_header = True
+            # Meta-Structural Era batch 3 — detect `inherited when`: the
+            # `inherited` operator precedes the `when` connective. Must
+            # match build.py's detection exactly (§7 invariant 4).
+            elif (
+                header_tokens
+                and header_tokens[0].type is TokenType.OPERATOR
+                and header_tokens[0].value == "inherited"
+                and len(header_tokens) > 1
+                and header_tokens[1].type is TokenType.CONNECTIVE
+                and header_tokens[1].value == "when"
             ):
                 is_when_header = True
 

--- a/src/liminate/vocabulary.py
+++ b/src/liminate/vocabulary.py
@@ -72,6 +72,12 @@ Sources:
   total) — `starting` connective (effective date) and `until`
   connective (sunset clause). Statement-initial modifiers with quoted
   ISO 8601 dates as inert AST metadata. Hard termination (DT-Q5).
+- v0.12.0 (Invariant-readiness) — NO vocabulary change; the count holds
+  at 58 reserved words. `inherited when` reuses the existing `inherited`
+  operator + `when` connective. The new `ResultStatus.PACK_VERB_FAILURE`
+  (see result.py) is a result-stream status, not a reserved word: pack
+  verb verification failures (cite/verify/measure) surface there with
+  structured failure metadata instead of mutating only the symbol table.
 """
 
 from dataclasses import dataclass

--- a/tests/_v3a_helpers.py
+++ b/tests/_v3a_helpers.py
@@ -71,6 +71,15 @@ def run_v3a(
                 toks = []
             if toks and toks[0].type is TokenType.CONNECTIVE and toks[0].value == "when":
                 is_when = True
+            # v0.12.0 — `inherited when` header (mirrors run.py / build.py).
+            elif (
+                len(toks) > 1
+                and toks[0].type is TokenType.OPERATOR
+                and toks[0].value == "inherited"
+                and toks[1].type is TokenType.CONNECTIVE
+                and toks[1].value == "when"
+            ):
+                is_when = True
 
         if is_when:
             action_lines: list[str] = []

--- a/tests/test_forbid.py
+++ b/tests/test_forbid.py
@@ -183,6 +183,19 @@ def test_forbid_reports_actual_value():
     assert "total is 15000" in (r.message or "")
 
 
+def test_forbid_violation_carries_structured_metadata():
+    # v0.12.0: PROHIBITION_VIOLATED results carry machine-readable failure
+    # identity (verb / condition / actual) for downstream comparison.
+    s = _session()
+    s.run_line("remember a value called total with 15000")
+    r = s.run_line("forbid total is above 10000")
+    assert r.status is ResultStatus.PROHIBITION_VIOLATED
+    assert r.metadata is not None
+    assert r.metadata["verb"] == "forbid"
+    assert r.metadata["condition"] == "total is above 10000"
+    assert "total is 15000" in r.metadata["actual"]
+
+
 def test_forbid_compound_true_violates():
     s = _session()
     s.run_line("remember a value called total with 20000")

--- a/tests/test_inherited.py
+++ b/tests/test_inherited.py
@@ -321,10 +321,60 @@ def test_inherited_inside_when_action_block():
     assert node.action.inherited_from == "agent-a"
 
 
-def test_inherited_when_header_is_rejected():
-    # `inherited when` (an inherited reactive handler) is out of scope.
-    # The `when` block parser entry rejects a leading `inherited` operator.
-    result = parse(tokenize("inherited when level is above 50"))
+def test_inherited_when_header_parses():
+    # v0.12.0: `inherited when` (an inherited reactive handler) is now
+    # supported. The `inherited` operator precedes the `when` connective on
+    # the header line; parse_when_block strips it and flags the WhenNode.
+    header = tokenize("inherited when level is above 50")
+    actions = [tokenize("show level")]
+    node = parse_when_block(header, actions)
+    assert not hasattr(node, "status"), getattr(node, "message", node)
+    assert node.inherited is True
+    # Agent attribution on `when` headers is deferred (build §4.2).
+    assert node.inherited_from is None
+
+
+def test_inherited_when_with_unless_guard_parses():
+    # The `inherited` prefix composes with an `unless` guard.
+    header = tokenize("inherited when level is above 50 unless level is above 90")
+    actions = [tokenize("show level")]
+    node = parse_when_block(header, actions)
+    assert not hasattr(node, "status"), getattr(node, "message", node)
+    assert node.inherited is True
+    assert node.unless is not None
+
+
+def test_non_inherited_when_header_not_flagged():
+    # A plain `when` header leaves the flag false (no `inherited` key
+    # should reach downstream trigger metadata).
+    header = tokenize("when level is above 50")
+    actions = [tokenize("show level")]
+    node = parse_when_block(header, actions)
+    assert not hasattr(node, "status"), getattr(node, "message", node)
+    assert node.inherited is False
+    assert node.inherited_from is None
+
+
+def test_inherited_when_renders_with_prefix():
+    # Round-trip fidelity: the canonical rendering prepends `inherited`.
+    header = tokenize("inherited when level is above 50")
+    actions = [tokenize("show level")]
+    node = parse_when_block(header, actions)
+    rendered = render(node)
+    assert rendered.startswith("inherited when ")
+    # Re-parsing the rendered header preserves the flag.
+    lines = rendered.split("\n")
+    reparsed = parse_when_block(
+        tokenize(lines[0]),
+        [tokenize(line.strip()) for line in lines[1:] if line.strip()],
+    )
+    assert not hasattr(reparsed, "status"), getattr(reparsed, "message", reparsed)
+    assert reparsed.inherited is True
+
+
+def test_inherited_when_missing_when_is_parse_error():
+    # `inherited` not followed by `when` (in the when-block entry) errors.
+    result = parse_when_block(tokenize("inherited"), [tokenize("show level")])
     assert result.status is ResultStatus.ERROR_PARSE
 
 

--- a/tests/test_integration_research_pack.py
+++ b/tests/test_integration_research_pack.py
@@ -113,8 +113,12 @@ def test_check_multiple_fields_in_one_release():
 # ---------------------------------------------------------------------------
 
 
-def test_check_identifier_not_found_is_semantic_error():
-    """check fails when the identifier is NOT in the release string."""
+def test_check_identifier_not_found_is_pack_verb_failure():
+    """check fails when the identifier is NOT in the release string.
+
+    v0.12.0: a substring miss surfaces as PACK_VERB_FAILURE (was
+    ERROR_SEMANTIC) — the data didn't satisfy the check, not a program bug.
+    """
     _, results = run_v3a(
         """
         remember a release called bls-release with "USDL-26-0684 | ages 18 to 38"
@@ -122,14 +126,17 @@ def test_check_identifier_not_found_is_semantic_error():
         """,
         pack=_load_research_pack(),
     )
-    errors = [r for r in results if r.status is ResultStatus.ERROR_SEMANTIC]
+    errors = [r for r in results if r.status is ResultStatus.PACK_VERB_FAILURE]
     assert errors, results
     assert "USDL-24-0626" in errors[0].message
     assert "bls-release" in errors[0].message
 
 
-def test_check_wrong_coverage_is_semantic_error():
-    """check fails when the coverage window doesn't match."""
+def test_check_wrong_coverage_is_pack_verb_failure():
+    """check fails when the coverage window doesn't match.
+
+    v0.12.0: surfaces as PACK_VERB_FAILURE (was ERROR_SEMANTIC).
+    """
     _, results = run_v3a(
         """
         remember a release called bls-release with "USDL-26-0684 | ages 18 to 38"
@@ -137,7 +144,7 @@ def test_check_wrong_coverage_is_semantic_error():
         """,
         pack=_load_research_pack(),
     )
-    errors = [r for r in results if r.status is ResultStatus.ERROR_SEMANTIC]
+    errors = [r for r in results if r.status is ResultStatus.PACK_VERB_FAILURE]
     assert errors, results
     assert "ages 18 to 36" in errors[0].message
 
@@ -253,7 +260,11 @@ def test_cite_measure_and_check_together():
 
 
 def test_check_fails_while_cite_passes():
-    """Model cited correct text but wrong release — the NLSY97 experiment case."""
+    """Model cited correct text but wrong release — the NLSY97 experiment case.
+
+    v0.12.0: the failing `check` surfaces as PACK_VERB_FAILURE (was
+    ERROR_SEMANTIC); the passing `cite` is SUCCESS.
+    """
     _, results = run_v3a(
         """
         remember a source called bls with "9.4 jobs from age 18 through age 38"
@@ -263,7 +274,7 @@ def test_check_fails_while_cite_passes():
         """,
         pack=_load_merged_pack(),
     )
-    errors = [r for r in results if r.status is ResultStatus.ERROR_SEMANTIC]
+    errors = [r for r in results if r.status is ResultStatus.PACK_VERB_FAILURE]
     assert len(errors) == 1, results
     assert "USDL-24-0626" in errors[0].message
     assert "meta" in errors[0].message

--- a/tests/test_integration_session_pack.py
+++ b/tests/test_integration_session_pack.py
@@ -92,8 +92,12 @@ def test_cite_multiple_facts_from_same_source():
 # ---------------------------------------------------------------------------
 
 
-def test_cite_text_not_found_is_semantic_error():
-    """cite fails with ERROR_SEMANTIC when text is absent from source."""
+def test_cite_text_not_found_is_pack_verb_failure():
+    """cite fails with PACK_VERB_FAILURE when text is absent from source.
+
+    v0.12.0: a substring miss is a data-verification failure, not a
+    program bug — it surfaces as PACK_VERB_FAILURE (was ERROR_SEMANTIC).
+    """
     _, results = run_v3a(
         """
         remember a source called readme with "Liminate has 11 verbs."
@@ -101,10 +105,15 @@ def test_cite_text_not_found_is_semantic_error():
         """,
         pack=_load_session_pack(),
     )
-    errors = [r for r in results if r.status is ResultStatus.ERROR_SEMANTIC]
+    errors = [r for r in results if r.status is ResultStatus.PACK_VERB_FAILURE]
     assert errors, results
     assert "35 reserved words" in errors[0].message
     assert "readme" in errors[0].message
+    # Structured failure identity (v0.12.0).
+    assert errors[0].metadata["verb"] == "cite"
+    assert errors[0].metadata["failure_type"] == "substring_not_found"
+    assert errors[0].metadata["check_value"] == "35 reserved words"
+    assert errors[0].metadata["against_name"] == "readme"
 
 
 def test_cite_from_non_source_typed_symbol_is_semantic_error():
@@ -439,7 +448,11 @@ def test_cite_fails_but_measure_passes():
         """,
         pack=_load_session_pack(),
     )
-    cite_errors = [r for r in results if r.status is ResultStatus.ERROR_SEMANTIC]
+    # v0.12.0: cite's substring miss surfaces as PACK_VERB_FAILURE; the
+    # measure passes (within tolerance) so it does not.
+    cite_errors = [
+        r for r in results if r.status is ResultStatus.PACK_VERB_FAILURE
+    ]
     assert len(cite_errors) == 1
     assert "76.3 percent" in cite_errors[0].message
 

--- a/tests/test_integration_v2_pack_extension.py
+++ b/tests/test_integration_v2_pack_extension.py
@@ -98,9 +98,10 @@ def test_cite_substring_check_failure():
     cite "Einstein" from doc
     '''
     _, results = run_v3a(src, pack=_test_pack())
+    # v0.12.0: substring miss surfaces as PACK_VERB_FAILURE.
     errors = [
         r for r in results
-        if r.status in (ResultStatus.ERROR_RUNTIME, ResultStatus.ERROR_SEMANTIC)
+        if r.status is ResultStatus.PACK_VERB_FAILURE
     ]
     assert errors
     assert "Einstein" in errors[0].message

--- a/tests/test_integration_v3a.py
+++ b/tests/test_integration_v3a.py
@@ -1190,3 +1190,60 @@ def test_u3_watching_list_in_registration_order():
     )
     assert expected in text
 
+
+
+# ---------------------------------------------------------------------------
+# v0.12.0 — `inherited when` HANDLER_FIRE metadata propagation
+# ---------------------------------------------------------------------------
+
+
+def test_inherited_when_fire_carries_inherited_metadata():
+    # v0.12.0: a handler declared with `inherited when` propagates the
+    # provenance flag into every HANDLER_FIRE result's trigger metadata so
+    # downstream consumers (Invariant) can distinguish pre-flight checklist
+    # handlers from session-authored handlers.
+    pack = TestDomainPack(
+        declarations=[],
+        script=[("temperature", 105), "[done]"],
+        name="test",
+    )
+    session, results = run_v3a(
+        """
+        remember a number called temperature with 50
+        inherited when temperature is above 100
+          show "high alert"
+        """,
+        pack=pack,
+    )
+    handler_fires = fires(results)
+    assert len(handler_fires) == 1
+    assert handler_fires[0].output == ["high alert"]
+    trigger = handler_fires[0].metadata["trigger"]
+    assert trigger["inherited"] is True
+    # Agent attribution on `when` headers is deferred — no inherited_from key.
+    assert "inherited_from" not in trigger
+    # The base trigger envelope is preserved alongside the inherited flag.
+    assert trigger["source"] == "adapter_update"
+
+
+def test_non_inherited_when_fire_omits_inherited_metadata():
+    # A plain `when` handler's HANDLER_FIRE metadata must NOT carry the
+    # `inherited` key — its absence is how consumers read "session-authored."
+    pack = TestDomainPack(
+        declarations=[],
+        script=[("temperature", 105), "[done]"],
+        name="test",
+    )
+    session, results = run_v3a(
+        """
+        remember a number called temperature with 50
+        when temperature is above 100
+          show "high alert"
+        """,
+        pack=pack,
+    )
+    handler_fires = fires(results)
+    assert len(handler_fires) == 1
+    trigger = handler_fires[0].metadata["trigger"]
+    assert "inherited" not in trigger
+    assert "inherited_from" not in trigger

--- a/tests/test_pack_attribution.py
+++ b/tests/test_pack_attribution.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 from liminate.adapter import TestDomainPack, parse_pack_verb_signature
 from liminate.cli import Session
+from liminate.result import ResultStatus
 
 
 def _load_session_pack() -> TestDomainPack:
@@ -73,3 +74,79 @@ def test_base_verb_no_pack_loaded():
     assert result is not None
     if result.metadata is not None:
         assert "pack" not in result.metadata
+
+
+# ---------------------------------------------------------------------------
+# v0.12.0 — structured failure identity on PACK_VERB_FAILURE results
+# ---------------------------------------------------------------------------
+
+
+def test_cite_failure_metadata_structure():
+    """A failing cite surfaces PACK_VERB_FAILURE with structured failure
+    identity AND pack attribution merged into one metadata dict."""
+    pack = _load_session_pack()
+    session = Session(domain_packs=[pack])
+
+    session.run_line('remember a source called s with "hello world"')
+    result = session.run_line('cite "goodbye" from s')
+
+    assert result is not None
+    assert result.status is ResultStatus.PACK_VERB_FAILURE
+    md = result.metadata
+    assert md is not None
+    assert md["verb"] == "cite"
+    assert md["failure_type"] == "substring_not_found"
+    assert md["check_value"] == "goodbye"
+    assert md["against_name"] == "s"
+    # Pack attribution is preserved alongside the failure identity.
+    assert md["pack"] == pack.name()
+
+
+def test_verify_mismatch_is_pack_verb_failure_with_metadata():
+    """A diverging verify surfaces PACK_VERB_FAILURE with comparison status
+    in its failure metadata (was SUCCESS with only a symbol-table flag)."""
+    pack = _load_session_pack()
+    session = Session(domain_packs=[pack])
+
+    session.run_line(
+        'remember a claim called expected with name as "a" and value as 1'
+    )
+    session.run_line(
+        'remember a source called snapshot with name as "a" and value as 2'
+    )
+    result = session.run_line("verify expected from snapshot")
+
+    assert result is not None
+    assert result.status is ResultStatus.PACK_VERB_FAILURE
+    md = result.metadata
+    assert md is not None
+    assert md["verb"] == "verify"
+    assert md["failure_type"].startswith("comparison_")
+    assert md["status"] != "match"
+    assert md["pack"] == pack.name()
+    # Symbol-table writes still happen for handler visibility.
+    assert session.symtab["verification-status"].value != "match"
+
+
+def test_measure_outside_tolerance_is_pack_verb_failure_with_metadata():
+    """A measure outside tolerance surfaces PACK_VERB_FAILURE carrying the
+    claimed/closest/delta/tolerance identity (was SUCCESS with only a flag)."""
+    pack = _load_session_pack()
+    session = Session(domain_packs=[pack])
+
+    session.run_line('remember a source called bls with "76 percent of weeks"')
+    result = session.run_line("measure 90 from bls within 1")
+
+    assert result is not None
+    assert result.status is ResultStatus.PACK_VERB_FAILURE
+    md = result.metadata
+    assert md is not None
+    assert md["verb"] == "measure"
+    assert md["failure_type"] == "outside_tolerance"
+    assert md["claimed"] == 90
+    assert md["closest"] == 76
+    assert md["delta"] == 14
+    assert md["tolerance"] == 1
+    assert md["pack"] == pack.name()
+    # Symbol-table writes still happen for handler visibility.
+    assert session.symtab["measure-status"].value == "outside_tolerance"

--- a/tests/test_require.py
+++ b/tests/test_require.py
@@ -192,6 +192,19 @@ def test_require_fails_with_message_and_actual():
     assert "amount is 30000" in (r.message or "")
 
 
+def test_require_failure_carries_structured_metadata():
+    # v0.12.0: REQUIREMENT_NOT_MET results carry machine-readable failure
+    # identity (verb / condition / actual) for downstream comparison.
+    s = _session()
+    s.run_line("remember a value called amount with 30000")
+    r = s.run_line("require amount is above 50000")
+    assert r.status is ResultStatus.REQUIREMENT_NOT_MET
+    assert r.metadata is not None
+    assert r.metadata["verb"] == "require"
+    assert r.metadata["condition"] == "amount is above 50000"
+    assert "amount is 30000" in r.metadata["actual"]
+
+
 def test_require_includes_fails():
     s = _session()
     s.run_line('remember a list called roles with "user"')

--- a/tests/test_require_each.py
+++ b/tests/test_require_each.py
@@ -146,6 +146,21 @@ def test_one_fails_scalar_list_identifies_element():
     assert "element 2" in (r.message or "")
 
 
+def test_require_each_failure_carries_structured_metadata():
+    # v0.12.0: iterated REQUIREMENT_NOT_MET carries the binding, collection,
+    # and 0-based element index alongside the condition/actual identity.
+    s = _session()
+    s.run_line("remember a list called scores with 80 and 60 and 75")
+    r = s.run_line("require each score in scores is above 70")
+    assert r.status is ResultStatus.REQUIREMENT_NOT_MET
+    assert r.metadata is not None
+    assert r.metadata["verb"] == "require"
+    assert r.metadata["iteration"] == "each"
+    assert r.metadata["binding"] == "score"
+    assert r.metadata["collection"] == "scores"
+    assert r.metadata["element_index"] == 1  # 0-based; element 2 in the message
+
+
 # ---------------------------------------------------------------------------
 # Integration — record lists
 # ---------------------------------------------------------------------------

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -4,7 +4,7 @@
 from liminate.result import LiminateResult, ResultStatus
 
 
-def test_all_ten_statuses_present():
+def test_all_statuses_present():
     # v3a §122: the five-outcome taxonomy is extended by four
     # listener-mode statuses (LISTENING, HANDLER_FIRE, SHUTDOWN,
     # ERROR_RUNTIME) for Phase 2 execution. Normative Era batch 2
@@ -15,12 +15,16 @@ def test_all_ten_statuses_present():
     # a prohibited condition evaluates true. Deontic Era batch 2 adds
     # PERMITTED — informational, for the receipt's deontic_mode envelope
     # (the interpreter returns SUCCESS for `permit`, not PERMITTED).
+    # v0.12.0 adds PACK_VERB_FAILURE — a pack verb's verification check
+    # (cite/verify/measure) found a mismatch; distinct from ERROR_SEMANTIC
+    # ("the program has a bug") — the data didn't satisfy the check.
     names = {s.name for s in ResultStatus}
     assert names == {
         "SUCCESS", "AMBER_PRECEDENCE", "AMBER_AMBIGUITY",
         "ERROR_PARSE", "ERROR_SEMANTIC",
         "LISTENING", "HANDLER_FIRE", "SHUTDOWN", "ERROR_RUNTIME",
         "REQUIREMENT_NOT_MET", "PROHIBITION_VIOLATED", "PERMITTED",
+        "PACK_VERB_FAILURE",
     }
 
 


### PR DESCRIPTION
Implements the three backflow changes from the Invariant Inception Checkpoint v1 that make the interpreter's result stream machine-readable for downstream embedders (Invariant, Receipts, contract-inheritance).

## Breaking changes
- `cite` substring miss: `ERROR_SEMANTIC` → **`PACK_VERB_FAILURE`**
- `verify` structural/equality mismatch: `SUCCESS` (flag mode) / `ERROR_SEMANTIC` (error mode) → **`PACK_VERB_FAILURE`** (both modes now raise)
- `measure` outside tolerance / no numbers found: `SUCCESS` (flag) / `ERROR_SEMANTIC` (error) → **`PACK_VERB_FAILURE`** (both modes now raise)

Symbol-table writes (`verification-status`, `measure-status`, `verification-divergences`, …) still happen **before** the raise, so `when` handlers watching those values keep working. A `PACK_VERB_FAILURE` sets the Phase-1 error gate (blocks Phase 2, reflected in exit code) but does not halt sequential Phase-1 execution.

## New
- **`inherited when` blocks.** `WhenNode` gains inert `inherited`/`inherited_from` provenance fields. `parse_when_block` consumes a leading `inherited` operator; `run.py`, `build.py`, and the v3a test helper detect `inherited when` headers identically. `HANDLER_FIRE` trigger metadata carries `"inherited": true` so consumers can distinguish pre-flight checklist handlers from session-authored handlers. Agent attribution (`from <agent>`) on `when` headers is deferred — the flag alone is sufficient for Invariant.
- **Structured failure identity** on `REQUIREMENT_NOT_MET` and `PROHIBITION_VIOLATED` results: `metadata` carries `verb`, `condition`, `actual` (plus `binding`/`collection`/`element_index` for `require each`).

## Notes beyond the literal spec
- `_stepwise_error` now propagates `failure.metadata`, so structured failure identity survives sequence (`then`/`and`) failures instead of being dropped.
- `_wrap_with_trigger` merges metadata (`{**(base.metadata or {}), "trigger": …}`) rather than clobbering, so a pack-verb failure inside a `when` block keeps its failure metadata alongside the trigger envelope.

## Version / vocabulary
- `0.11.0` → `0.12.0`. No vocabulary change — still **58** reserved words (`inherited when` reuses the existing `inherited` operator + `when` connective).

## Tests
- Full suite: **1351 passed** (+12 new). Updated assertions for the status change (no test logic changed); added metadata-structure tests for pack-verb failures and require/forbid/require-each; added `inherited when` parse/render/round-trip + `HANDLER_FIRE` propagation tests.

## Downstream consumers needing coordinated updates (separate prompts after merge)
- `liminate-dev` (Receipts server)
- `liminate-contract-inheritance` (extractor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)