### PR TITLE
feat: empty list construction + descending ranges and step values

### DIFF
--- a/src/liminate/analyzer.py
+++ b/src/liminate/analyzer.py
@@ -1254,15 +1254,12 @@ def _check_combine(node: CombineNode, symtab: dict[str, SymbolEntry]) -> None:
 
 
 def _check_gather(node: GatherNode) -> None:
-    if node.from_val > node.to_val:
-        raise _SemanticError(
-            f"The 'from' value ({_fmt_number(node.from_val)}) must be less "
-            f"than or equal to the 'to' value ({_fmt_number(node.to_val)}). "
-            f"Try: gather the {node.name} from {_fmt_number(node.to_val)} "
-            f"to {_fmt_number(node.from_val)}."
-        )
-    # Range size = to - from + 1 (inclusive).
-    size = node.to_val - node.from_val + 1
+    # D-6: descending ranges (from > to) are valid. Direction is derived
+    # from the endpoints; the step is always positive (enforced at parse
+    # time). Range size counts inclusive endpoints stepped by `step`.
+    step = node.step_val if node.step_val is not None else 1
+    span = abs(node.to_val - node.from_val)
+    size = int(span // step) + 1
     if size > GATHER_RANGE_CAP:
         raise _SemanticError(
             f"That range is too large. The maximum is "

--- a/src/liminate/interpreter.py
+++ b/src/liminate/interpreter.py
@@ -1326,10 +1326,23 @@ def _exec_count(node: CountNode, symtab: dict[str, SymbolEntry]) -> list[str]:
     return [str(len(entry.value))]
 
 
-def _exec_gather(node: GatherNode, symtab: dict[str, SymbolEntry]) -> list[str]:
+def _gather_items(node: GatherNode) -> list[int]:
+    """Materialize a gather range.
+
+    D-6: the step is always positive in the AST; the direction is derived
+    from comparing from_val and to_val. Ascending uses +step, descending
+    negates it for the Python range. Both endpoints are inclusive.
+    """
     start = int(node.from_val)
     stop = int(node.to_val)
-    items = list(range(start, stop + 1))
+    step = int(node.step_val) if node.step_val is not None else 1
+    if start <= stop:
+        return list(range(start, stop + 1, step))
+    return list(range(start, stop - 1, -step))
+
+
+def _exec_gather(node: GatherNode, symtab: dict[str, SymbolEntry]) -> list[str]:
+    items = _gather_items(node)
     _store(symtab, node.name, items)
     # v1b §40: gather both stores AND auto-shows.
     return _display_lines(items)
@@ -1900,9 +1913,7 @@ def _value_of_op(op: ASTNode, symtab: dict[str, SymbolEntry]) -> Any:
     if isinstance(op, CountNode):
         return len(symtab[op.target.name].value)
     if isinstance(op, GatherNode):
-        start = int(op.from_val)
-        stop = int(op.to_val)
-        items = list(range(start, stop + 1))
+        items = _gather_items(op)
         _store(symtab, op.name, items)
         return items
     if isinstance(op, RememberValueNode):

--- a/src/liminate/parser.py
+++ b/src/liminate/parser.py
@@ -317,6 +317,10 @@ class GatherNode(ASTNode):
     name: str
     from_val: int | float
     to_val: int | float
+    # D-6 — optional step value. None means the default step (1). The step
+    # is always stored positive; the direction (ascending vs descending) is
+    # derived from comparing from_val and to_val, never from the step sign.
+    step_val: int | float | None = None
     rationale: str | None = field(default=None, compare=False)
     # Meta-Structural Era batch 3 — `inherited` operator + `from`
     # attribution. Both are inert provenance metadata (compare=False),
@@ -2668,7 +2672,23 @@ def _parse_gather(stream: TokenStream) -> GatherNode:
         raise _ParseError("I expected a number after 'to'.")
     to_val = _parse_number(to_val_tok.value)
 
-    return GatherNode(name=name, from_val=from_val, to_val=to_val)
+    # D-6 — optional `by <number>` step value after `to <number>`. `by` is
+    # already a connective (used by `sort`); its tail here is non-overlapping.
+    step_val: int | float | None = None
+    peek = stream.peek()
+    if peek and peek.type is TokenType.CONNECTIVE and peek.value == "by":
+        stream.consume()  # eat `by`
+        step_tok = stream.consume()
+        if not step_tok or step_tok.type is not TokenType.NUMBER:
+            raise _ParseError("I expected a number after 'by' — the step value.")
+        step_val = _parse_number(step_tok.value)
+        if step_val <= 0:
+            raise _ParseError(
+                f"The step value must be positive — got {step_val}. "
+                f"The direction is determined by the range (from/to), not the step."
+            )
+
+    return GatherNode(name=name, from_val=from_val, to_val=to_val, step_val=step_val)
 
 
 # ---------------------------------------------------------------------------

--- a/src/liminate/renderer.py
+++ b/src/liminate/renderer.py
@@ -222,10 +222,14 @@ def _render_node(node: ASTNode) -> str:
     if isinstance(node, CountNode):
         return f"count the {render(node.target)}"
     if isinstance(node, GatherNode):
-        return (
+        out = (
             f"gather the {node.name} "
             f"from {_fmt_number(node.from_val)} to {_fmt_number(node.to_val)}"
         )
+        # D-6: render the step value back when present.
+        if node.step_val is not None:
+            out += f" by {_fmt_number(node.step_val)}"
+        return out
     if isinstance(node, CombineNode):
         return f"combine the {render(node.target)}"
     if isinstance(node, EachNode):

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -257,12 +257,10 @@ def test_mixed_type_list_is_semantic_error():
 # Sentence 42 — descending range
 # ---------------------------------------------------------------------------
 
-def test_descending_range_is_semantic_error():
+def test_descending_range_is_allowed():
+    # D-6: descending ranges are valid; the analyzer no longer rejects them.
     result = _analyze("gather the numbers from 10 to 1")
-    assert isinstance(result, LiminateResult)
-    assert result.status is ResultStatus.ERROR_SEMANTIC
-    assert "less than or equal to" in result.message
-    assert "10" in result.message and "1" in result.message
+    assert not isinstance(result, LiminateResult)
 
 
 def test_equal_endpoints_are_allowed():

--- a/tests/test_descending_ranges.py
+++ b/tests/test_descending_ranges.py
@@ -1,0 +1,211 @@
+"""Tests for D-6: descending ranges and step values for `gather`.
+
+Covers:
+- Descending ranges (`from 10 to 1`) count down inclusively.
+- Step values (`by N`) for both ascending and descending ranges.
+- The step is always positive; direction is derived from from/to.
+- Parse errors for non-positive / non-numeric step values.
+- Canonical rendering round-trips (with and without `by`).
+- The range cap still applies, computed from the stepped span.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from liminate.lexer import tokenize
+from liminate.parser import GatherNode, parse
+from liminate.renderer import render
+from liminate.result import ResultStatus
+
+from tests._v3a_helpers import outputs, run_v3a
+
+
+def _gather(src: str) -> list[int]:
+    """Run a single gather line and return the stored list."""
+    name = src.split()[2]  # `gather the <name> ...`
+    session, results = run_v3a(src)
+    errors = [r for r in results if r.status is not ResultStatus.SUCCESS]
+    assert not errors, errors
+    return session.symtab[name].value
+
+
+# ---------------------------------------------------------------------------
+# Descending ranges (no step)
+# ---------------------------------------------------------------------------
+
+
+def test_descending_basic():
+    assert _gather("gather the countdown from 5 to 1") == [5, 4, 3, 2, 1]
+
+
+def test_descending_to_ten_to_one():
+    assert _gather("gather the nums from 10 to 1") == [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
+
+
+def test_single_element_endpoints_equal():
+    assert _gather("gather the single from 3 to 3") == [3]
+
+
+def test_ascending_unchanged():
+    assert _gather("gather the sequence from 1 to 5") == [1, 2, 3, 4, 5]
+
+
+# ---------------------------------------------------------------------------
+# Step values — ascending
+# ---------------------------------------------------------------------------
+
+
+def test_step_evens():
+    assert _gather("gather the evens from 2 to 10 by 2") == [2, 4, 6, 8, 10]
+
+
+def test_step_fives():
+    assert _gather("gather the fives from 0 to 20 by 5") == [0, 5, 10, 15, 20]
+
+
+def test_step_three_reaches_stop():
+    assert _gather("gather the steps from 1 to 10 by 3") == [1, 4, 7, 10]
+
+
+def test_step_three_stop_not_reached():
+    assert _gather("gather the steps from 1 to 9 by 3") == [1, 4, 7]
+
+
+# ---------------------------------------------------------------------------
+# Step values — descending
+# ---------------------------------------------------------------------------
+
+
+def test_step_descending_by_two():
+    assert _gather("gather the countdown from 10 to 1 by 2") == [10, 8, 6, 4, 2]
+
+
+def test_step_descending_by_three_reaches_stop():
+    assert _gather("gather the countdown from 10 to 1 by 3") == [10, 7, 4, 1]
+
+
+def test_step_descending_by_three_stop_not_reached():
+    assert _gather("gather the countdown from 10 to 2 by 3") == [10, 7, 4]
+
+
+# ---------------------------------------------------------------------------
+# Auto-show output
+# ---------------------------------------------------------------------------
+
+
+def test_descending_auto_shows():
+    _, results = run_v3a("gather the countdown from 5 to 1")
+    assert outputs(results) == ["5, 4, 3, 2, 1"]
+
+
+def test_step_auto_shows():
+    _, results = run_v3a("gather the evens from 2 to 10 by 2")
+    assert outputs(results) == ["2, 4, 6, 8, 10"]
+
+
+# ---------------------------------------------------------------------------
+# Parse errors
+# ---------------------------------------------------------------------------
+
+
+def test_step_zero_is_parse_error():
+    _, results = run_v3a("gather the x from 1 to 10 by 0")
+    errors = [r for r in results if r.status is ResultStatus.ERROR_PARSE]
+    assert errors, results
+    assert "positive" in errors[0].message
+
+
+def test_step_negative_is_parse_error():
+    # Negative numbers are not NUMBER tokens, so this surfaces as
+    # "I expected a number after 'by'".
+    _, results = run_v3a("gather the x from 1 to 10 by -2")
+    errors = [r for r in results if r.status is ResultStatus.ERROR_PARSE]
+    assert errors, results
+
+
+def test_step_non_numeric_is_parse_error():
+    _, results = run_v3a("gather the x from 1 to 10 by hello")
+    errors = [r for r in results if r.status is ResultStatus.ERROR_PARSE]
+    assert errors, results
+
+
+# ---------------------------------------------------------------------------
+# Range cap still applies (computed from the stepped span)
+# ---------------------------------------------------------------------------
+
+
+def test_range_cap_still_enforced_descending():
+    _, results = run_v3a("gather the big from 20000 to 1")
+    errors = [r for r in results if r.status is ResultStatus.ERROR_SEMANTIC]
+    assert errors, results
+    assert "10,000" in errors[0].message
+
+
+def test_step_reduces_size_under_cap():
+    # 0..20000 by 5 → 4001 items, under the 10,000 cap.
+    session, results = run_v3a("gather the strided from 0 to 20000 by 5")
+    errors = [r for r in results if r.status is not ResultStatus.SUCCESS]
+    assert not errors, errors
+    assert len(session.symtab["strided"].value) == 4001
+
+
+# ---------------------------------------------------------------------------
+# Parser / AST
+# ---------------------------------------------------------------------------
+
+
+def test_parse_step_populates_step_val():
+    ast = parse(tokenize("gather the evens from 2 to 10 by 2"))
+    assert ast == GatherNode(name="evens", from_val=2, to_val=10, step_val=2)
+
+
+def test_parse_no_step_leaves_step_val_none():
+    ast = parse(tokenize("gather the nums from 1 to 10"))
+    assert ast.step_val is None
+
+
+# ---------------------------------------------------------------------------
+# Canonical rendering round-trips
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "src,canonical",
+    [
+        ("gather the countdown from 5 to 1", "gather the countdown from 5 to 1"),
+        ("gather the nums from 1 to 10", "gather the nums from 1 to 10"),
+        ("gather the evens from 2 to 10 by 2", "gather the evens from 2 to 10 by 2"),
+        ("gather the down from 100 to 1 by 10", "gather the down from 100 to 1 by 10"),
+    ],
+)
+def test_canonical_rendering(src, canonical):
+    assert render(parse(tokenize(src))) == canonical
+
+
+def test_canonical_round_trip_descending():
+    ast1 = parse(tokenize("gather the x from 10 to 1"))
+    ast2 = parse(tokenize(render(ast1)))
+    assert ast1 == ast2
+
+
+def test_canonical_round_trip_step():
+    ast1 = parse(tokenize("gather the x from 1 to 100 by 5"))
+    ast2 = parse(tokenize(render(ast1)))
+    assert ast1 == ast2
+
+
+# ---------------------------------------------------------------------------
+# Failure mode 2 — the `by` step is consumed cleanly and control returns to
+# the operation-sequence loop for a following verb.
+# ---------------------------------------------------------------------------
+
+
+def test_gather_step_then_sequenced_verb_does_not_collide():
+    session, results = run_v3a(
+        "gather the nums from 1 to 10 by 2 and count nums"
+    )
+    errors = [r for r in results if r.status is not ResultStatus.SUCCESS]
+    assert not errors, errors
+    assert session.symtab["nums"].value == [1, 3, 5, 7, 9]
+    assert outputs(results)[-1] == "5"

--- a/tests/test_empty_list.py
+++ b/tests/test_empty_list.py
@@ -1,0 +1,67 @@
+"""Tests for D-3: empty list construction.
+
+`remember a list called X` with no `with` clause produces an empty list,
+gated on the `list` descriptor. Covers the build-prompt acceptance criteria.
+(See also tests/test_integration_empty_list.py for the addendum-v4 suite.)
+"""
+
+from __future__ import annotations
+
+from liminate.lexer import tokenize
+from liminate.parser import RememberListNode, parse
+from liminate.renderer import render
+from liminate.result import ResultStatus
+
+from tests._v3a_helpers import outputs, run_v3a
+
+
+def test_empty_list_stored():
+    session, results = run_v3a("remember a list called items")
+    errors = [r for r in results if r.status is not ResultStatus.SUCCESS]
+    assert not errors, errors
+    assert session.symtab["items"].value == []
+
+
+def test_add_then_count_is_one():
+    session, results = run_v3a(
+        """
+        remember a list called items
+        add 5 to items
+        count items
+        """
+    )
+    errors = [r for r in results if r.status is not ResultStatus.SUCCESS]
+    assert not errors, errors
+    assert session.symtab["items"].value == [5]
+    assert outputs(results)[-1] == "1"
+
+
+def test_show_empty_list_is_clean():
+    _, results = run_v3a(
+        """
+        remember a list called items
+        show items
+        """
+    )
+    successes = [r for r in results if r.status is ResultStatus.SUCCESS]
+    assert len(successes) == 2
+
+
+def test_canonical_render_has_no_with():
+    ast = parse(tokenize("remember a list called items"))
+    assert isinstance(ast, RememberListNode)
+    assert ast.items == []
+    assert render(ast) == "remember a list called items"
+
+
+def test_value_descriptor_without_with_is_parse_error():
+    _, results = run_v3a("remember a value called items")
+    errors = [r for r in results if r.status is ResultStatus.ERROR_PARSE]
+    assert errors, results
+
+
+def test_empty_form_gated_on_list_descriptor():
+    # No descriptor at all (and no `with`) is still a parse error.
+    _, results = run_v3a("remember a thing called items")
+    errors = [r for r in results if r.status is ResultStatus.ERROR_PARSE]
+    assert errors, results

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -422,10 +422,11 @@ def test_sentence_41_mixed_type_list():
 
 
 def test_sentence_42_descending_range():
+    # D-6: descending ranges are now valid and count down inclusively.
     session = make_session()
     r = session.run_line("gather the numbers from 10 to 1")
-    assert r.status is ResultStatus.ERROR_SEMANTIC
-    assert "less than or equal" in r.message
+    assert r.status is ResultStatus.SUCCESS
+    assert session.symtab["numbers"].value == [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -599,9 +599,11 @@ def test_sentence_41_mixed_list():
 
 
 def test_sentence_42_descending_range():
-    r = run("gather the numbers from 10 to 1")
-    assert r.status is ResultStatus.ERROR_SEMANTIC
-    assert "less than or equal" in r.message
+    # D-6: descending ranges are now valid and count down inclusively.
+    symtab = {}
+    r = run("gather the numbers from 10 to 1", symtab)
+    assert r.status is ResultStatus.SUCCESS
+    assert symtab["numbers"].value == [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
 
 
 def test_sentence_43_range_cap_exceeded():


### PR DESCRIPTION
## Summary

Implements two deferred Phase 1 quality-of-life items (Checkpoint v18, D-3 and D-6).

### D-3 — Empty list construction
`remember a list called X` now produces an empty list when the `list` descriptor is present and no `with` clause follows. The parser (`_parse_remember`) and renderer already supported this path — this PR adds dedicated coverage in `tests/test_empty_list.py`. `remember a value called X` (no `list` descriptor, no `with`) still raises a parse error.

### D-6 — Descending ranges and step values for `gather`
- `gather the numbers from 10 to 1` → counts down inclusively.
- `gather the numbers from 1 to 100 by 5` → step values, ascending or descending.
- The step is **always positive**; direction is derived from comparing `from`/`to`. Non-positive or non-numeric steps are parse errors.

**Deviation from the build prompt:** §2 stated the analyzer needed no changes and that descending ranges currently produced an empty list. In fact the analyzer *rejected* descending ranges with `ERROR_SEMANTIC`. That rejection was removed, and the range cap is now recomputed as `abs(span) // step + 1` so it still fires for oversized (and descending) ranges. Three existing tests asserting the old error were updated to assert the new valid behavior.

## Files modified
- `parser.py` — `GatherNode.step_val` field; `_parse_gather` consumes optional `by <number>`.
- `interpreter.py` — shared `_gather_items()` helper (ascending/descending + step), used by `_exec_gather` and `_value_of_op`.
- `renderer.py` — renders ` by <step>` when present.
- `analyzer.py` — dropped descending rejection; range cap recomputed from the stepped span.

## Files created
- `tests/test_descending_ranges.py` (27 tests)
- `tests/test_empty_list.py` (6 tests)

## Tests updated
- `test_analyzer.py`, `test_integration.py`, `test_interpreter.py` — descending range is now valid.

## Verification
- `pytest tests/` → **1384 passed**.
- Manual gate passed.
- Consistency invariants (§5) satisfied: `GatherNode` backward-compatible (`step_val=None` default), empty-list rendering has no trailing `with`, step direction consistent across parser/interpreter/renderer, canonical round-trip verified for descending and stepped forms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)