### PR TITLE
Phase 2 Expressibility: D-1 composition param literals, D-4 contradiction detection, D-7 timer-driven decay, D-8 range_check + validate

### DIFF
--- a/examples/pack_research.json
+++ b/examples/pack_research.json
@@ -17,6 +17,23 @@
         "check_slot": "text",
         "against_slot": "target"
       }
+    },
+    {
+      "word": "validate",
+      "slots": [
+        { "name": "claimed", "connective": null, "required": true, "value_type": "value" },
+        { "name": "reference", "connective": "from", "required": true, "value_type": "name", "type_constraint": "window" }
+      ],
+      "execution": {
+        "type": "range_check",
+        "check_slot": "claimed",
+        "against_slot": "reference",
+        "on_mismatch": "flag",
+        "status_target": "range-status",
+        "claimed_target": "range-claimed",
+        "reference_target": "range-reference",
+        "divergence_target": "range-divergence"
+      }
     }
   ],
   "declarations": [],

--- a/src/liminate/adapter.py
+++ b/src/liminate/adapter.py
@@ -34,6 +34,7 @@ from .vocabulary import (
     PackVerbExecution,
     PackVerbSignature,
     PackVerbSlot,
+    RangeCheckExecution,
     SetFieldExecution,
     SetValueExecution,
     SubstringCheckExecution,
@@ -250,10 +251,20 @@ def _parse_execution(exec_def: dict) -> PackVerbExecution:
             matched_target=exec_def["matched_target"],
             delta_target=exec_def["delta_target"],
         )
+    if exec_type == "range_check":
+        return RangeCheckExecution(
+            check_slot=exec_def["check_slot"],
+            against_slot=exec_def["against_slot"],
+            on_mismatch=exec_def.get("on_mismatch", "flag"),
+            status_target=exec_def["status_target"],
+            claimed_target=exec_def["claimed_target"],
+            reference_target=exec_def["reference_target"],
+            divergence_target=exec_def["divergence_target"],
+        )
     raise ValueError(
         f"Unknown execution type '{exec_type}'. "
         f"Supported: set_value, substring_check, append_to_list, "
-        f"set_field, compare_values, numeric_extract_compare."
+        f"set_field, compare_values, numeric_extract_compare, range_check."
     )
 
 
@@ -359,6 +370,24 @@ def _validate_pack_verb_signature(sig: PackVerbSignature) -> None:
                 f"'{execution.on_mismatch}'. Use 'error' or 'flag'."
             )
         for field_name in ("status_target", "matched_target", "delta_target"):
+            v = getattr(execution, field_name)
+            if not isinstance(v, str) or not v:
+                raise ValueError(
+                    f"Pack verb '{word}': '{field_name}' must be a "
+                    f"non-empty string."
+                )
+
+    # range_check: extra validation.
+    if isinstance(execution, RangeCheckExecution):
+        if execution.on_mismatch not in ("error", "flag"):
+            raise ValueError(
+                f"Pack verb '{word}' uses unknown on_mismatch "
+                f"'{execution.on_mismatch}'. Use 'error' or 'flag'."
+            )
+        for field_name in (
+            "status_target", "claimed_target",
+            "reference_target", "divergence_target",
+        ):
             v = getattr(execution, field_name)
             if not isinstance(v, str) or not v:
                 raise ValueError(

--- a/src/liminate/analyzer.py
+++ b/src/liminate/analyzer.py
@@ -1380,14 +1380,16 @@ def _check_composition_call_shape(
     if param is not None and node.arg is None:
         raise _SemanticError(
             f"'{node.name}' expects an input (from <{param}>). "
-            f"Try: {node.name} from <your-list>."
+            f"Try: {node.name} from <your-list> or {node.name} from 50."
         )
     if param is None and node.arg is not None:
         raise _SemanticError(
             f"'{node.name}' doesn't take an input. "
             f"Call it on its own: {node.name}."
         )
-    if node.arg is not None and node.arg not in symtab:
+    # Phase 2 D-1 — a literal argument is self-contained; only a bare-name
+    # argument (str) needs a symbol-table existence check.
+    if isinstance(node.arg, str) and node.arg not in symtab:
         raise _SemanticError(
             f"I can't find '{node.arg}'. "
             f"You might need to 'remember' it first."
@@ -1424,7 +1426,15 @@ def _analyze_composition_body(
         )
         return
     original = symtab.get(param)
-    symtab[param] = symtab[node.arg]  # alias for analysis only
+    # Phase 2 D-1 — bind the param for analysis. A literal argument
+    # synthesizes a SymbolEntry directly; a bare name aliases the existing
+    # entry (analysis-only, mirroring the runtime bind in _bind_parameter).
+    if isinstance(node.arg, NumberLiteral):
+        symtab[param] = SymbolEntry(name=param, value=node.arg.value, type="number")
+    elif isinstance(node.arg, QuotedString):
+        symtab[param] = SymbolEntry(name=param, value=node.arg.content, type="string")
+    else:
+        symtab[param] = symtab[node.arg]  # alias for analysis only
     try:
         _check(
             body, symtab, iterator=None,

--- a/src/liminate/analyzer.py
+++ b/src/liminate/analyzer.py
@@ -93,6 +93,7 @@ from .vocabulary import (
     AppendToListExecution,
     CompareValuesExecution,
     NumericExtractCompareExecution,
+    RangeCheckExecution,
     SetFieldExecution,
     SetValueExecution,
     SubstringCheckExecution,
@@ -1752,6 +1753,8 @@ def _check_pack_verb(
         _check_pack_compare(node, execution, symtab)
     elif isinstance(execution, NumericExtractCompareExecution):
         _check_pack_numeric_extract(node, execution, symtab)
+    elif isinstance(execution, RangeCheckExecution):
+        _check_pack_range_check(node, execution, symtab)
     # SetValueExecution: nothing further beyond type_constraint loop.
 
 
@@ -1913,6 +1916,43 @@ def _check_pack_numeric_extract(
             f"'{node.word} from' expects text, but '{name}' is "
             f"{_singular(entry.type)}."
         )
+
+
+def _check_pack_range_check(
+    node: PackVerbNode,
+    execution: RangeCheckExecution,
+    symtab: dict[str, SymbolEntry],
+) -> None:
+    """D-8 — `range_check` analyzer validation. Mirrors substring_check: the
+    `against_slot` (reference window) must be a name that exists and resolves
+    to a string; the `check_slot` (claimed range) is validated only when it is
+    a name reference (literals and field access are trivially valid)."""
+    against_node = node.slot_values.get(execution.against_slot)
+    if not isinstance(against_node, NameRef):
+        raise _SemanticError(
+            f"'{node.word}' expects a name for the reference window."
+        )
+    name = against_node.name
+    if name not in symtab:
+        raise _SemanticError(
+            f"I can't find '{name}'. "
+            f"You might need to 'remember' it first."
+        )
+    entry = symtab[name]
+    if entry.type != "string":
+        raise _SemanticError(
+            f"'{node.word} from' expects text, but '{name}' is "
+            f"{_singular(entry.type)}."
+        )
+    check_node = node.slot_values.get(execution.check_slot)
+    if isinstance(check_node, NameRef):
+        if check_node.name not in symtab:
+            raise _SemanticError(
+                f"I can't find '{check_node.name}'. "
+                f"You might need to 'remember' it first."
+            )
+    elif isinstance(check_node, FieldAccessNode):
+        _check_field_access(check_node, symtab)
 
 
 def _check_finish(

--- a/src/liminate/analyzer.py
+++ b/src/liminate/analyzer.py
@@ -230,6 +230,152 @@ def analyze(
 
 
 # ---------------------------------------------------------------------------
+# Phase 2 D-4 — deontic contradiction detection
+# ---------------------------------------------------------------------------
+#
+# A static, warning-only analysis pass that runs once over the whole program
+# (before execution) and reports direct, same-field logical conflicts between
+# `require` and `forbid` statements. It never blocks execution and never
+# changes a result status — it only produces informational warning strings.
+#
+# Scope (locked decisions DT-Q2/DT-Q3 + the §3 design):
+#   - Only RequireNode and ForbidNode participate. PermitNode is purely
+#     informational and never contradicts anything (DT-Q3).
+#   - Only *simple* conditions are checked — a single leaf ConditionNode with
+#     a NameRef field and a NumberLiteral / BareWord / QuotedString value.
+#     Compound (`and`/`or`) conditions are out of scope and are skipped
+#     entirely (no leaf extraction across statements → no false positives).
+#   - No SAT solving; only the four direct-conflict rules below.
+
+
+# One extracted, checkable deontic statement: its verb, field name, the
+# normalized comparison operator, and the (kind, value) pair. `text` is the
+# human-readable rendering used in the warning message.
+class _Deontic:
+    __slots__ = ("verb", "field", "op", "kind", "value", "text")
+
+    def __init__(self, verb, field, op, kind, value, text):
+        self.verb = verb      # "require" | "forbid"
+        self.field = field    # field name (str)
+        self.op = op          # normalized: "above" | "below" | "is"
+        self.kind = kind      # "num" | "str"
+        self.value = value    # int/float for "num", str for "str"
+        self.text = text      # e.g. "require x is above 50"
+
+
+def _iter_deontic_nodes(statements):
+    """Yield each RequireNode / ForbidNode found in `statements`, descending
+    into SequenceNode operations. PermitNode is skipped — it never
+    contradicts (DT-Q3)."""
+    for stmt in statements:
+        if isinstance(stmt, SequenceNode):
+            yield from _iter_deontic_nodes(stmt.operations)
+        elif isinstance(stmt, (RequireNode, ForbidNode)):
+            yield stmt
+
+
+def _extract_deontic(node) -> "_Deontic | None":
+    """Reduce a RequireNode/ForbidNode to a checkable `_Deontic`, or None if
+    its condition is out of scope (compound, non-name field, or a value that
+    isn't a literal / bareword)."""
+    cond = node.condition
+    # Compound conditions are out of scope — skip entirely (no leaf extraction).
+    if not isinstance(cond, ConditionNode):
+        return None
+    if not isinstance(cond.field, NameRef):
+        return None
+    field = cond.field.name
+
+    val = cond.value
+    if isinstance(val, NumberLiteral):
+        kind, value, value_text = "num", val.value, _fmt_value_num(val.value)
+    elif isinstance(val, BareWord):
+        kind, value, value_text = "str", val.word, val.word
+    elif isinstance(val, QuotedString):
+        kind, value, value_text = "str", val.content, val.content
+    else:
+        # NameRef / EachPronoun / anything symbolic — not statically checkable.
+        return None
+
+    # Normalize equality: bare `is` and `is equal to` both mean equality.
+    raw_op = cond.op
+    if raw_op in ("is", "equal_to"):
+        op = "is"
+    elif raw_op in ("above", "below"):
+        op = raw_op
+    else:
+        # not_above / not_below / within / includes etc. are out of scope.
+        return None
+
+    verb = "require" if isinstance(node, RequireNode) else "forbid"
+    phrase = {"above": "is above", "below": "is below", "is": "is"}[op]
+    text = f"{verb} {field} {phrase} {value_text}"
+    return _Deontic(verb, field, op, kind, value, text)
+
+
+def _fmt_value_num(value) -> str:
+    return str(int(value)) if isinstance(value, int) else str(value)
+
+
+def _values_equal(a: _Deontic, b: _Deontic) -> bool:
+    return a.kind == b.kind and a.value == b.value
+
+
+def _pair_contradicts(a: _Deontic, b: _Deontic) -> bool:
+    """Apply the four direct-conflict rules to a same-field pair."""
+    if a.field != b.field:
+        return False
+    verbs = {a.verb, b.verb}
+
+    # Rule 1 — identical operator AND value, one require + one forbid. Any
+    # value of the field that satisfies one violates the other. Subsumes the
+    # `is`-equality require/forbid case (rule 3 in the design table).
+    if a.op == b.op and _values_equal(a, b) and verbs == {"require", "forbid"}:
+        return True
+
+    # Rules 2 and 4 are require + require only.
+    if a.verb == "require" and b.verb == "require":
+        # Rule 2 — an `above A` requirement and a `below B` requirement with
+        # A >= B leave no satisfying value (empty open interval).
+        ops = {a.op, b.op}
+        if ops == {"above", "below"} and a.kind == "num" and b.kind == "num":
+            above_val = a.value if a.op == "above" else b.value
+            below_val = a.value if a.op == "below" else b.value
+            if above_val >= below_val:
+                return True
+        # Rule 4 — two equality requirements with different values can never
+        # both hold.
+        if a.op == "is" and b.op == "is" and not _values_equal(a, b):
+            return True
+
+    return False
+
+
+def detect_contradictions(statements: list[ASTNode]) -> list[str]:
+    """Walk top-level ASTs, collect simple `require`/`forbid` conditions, and
+    report direct same-field logical conflicts.
+
+    Returns a list of human-readable warning strings (empty when none found).
+    This is advisory only: the caller surfaces the warnings but never halts
+    execution on them (D-4 locked: warning-only).
+    """
+    deontics = [
+        d for node in _iter_deontic_nodes(statements)
+        if (d := _extract_deontic(node)) is not None
+    ]
+    warnings: list[str] = []
+    for i in range(len(deontics)):
+        for j in range(i + 1, len(deontics)):
+            a, b = deontics[i], deontics[j]
+            if _pair_contradicts(a, b):
+                warnings.append(
+                    f"Possible contradiction: '{a.text}' conflicts with "
+                    f"'{b.text}' — no value of {a.field} can satisfy both."
+                )
+    return warnings
+
+
+# ---------------------------------------------------------------------------
 # Dispatch
 # ---------------------------------------------------------------------------
 

--- a/src/liminate/interpreter.py
+++ b/src/liminate/interpreter.py
@@ -1755,19 +1755,27 @@ def _bind_parameter(
     param = entry.composition_param
     if param is None or node.arg is None:
         return None, None, False
-    arg_entry = symtab[node.arg]
     saved = symtab.get(param)
-    symtab[param] = SymbolEntry(
-        name=param,
-        value=copy.deepcopy(arg_entry.value),
-        type=arg_entry.type,
-        schema=copy.deepcopy(arg_entry.schema),
-        source_names=(
-            list(arg_entry.source_names)
-            if arg_entry.source_names is not None
-            else None
-        ),
-    )
+    # Phase 2 D-1 — a literal argument is self-contained: bind the param
+    # directly to the literal's value. A bare name (str) follows the v2d §96
+    # path: look up, deep-copy, and carry the source entry's metadata.
+    if isinstance(node.arg, NumberLiteral):
+        symtab[param] = SymbolEntry(name=param, value=node.arg.value, type="number")
+    elif isinstance(node.arg, QuotedString):
+        symtab[param] = SymbolEntry(name=param, value=node.arg.content, type="string")
+    else:
+        arg_entry = symtab[node.arg]
+        symtab[param] = SymbolEntry(
+            name=param,
+            value=copy.deepcopy(arg_entry.value),
+            type=arg_entry.type,
+            schema=copy.deepcopy(arg_entry.schema),
+            source_names=(
+                list(arg_entry.source_names)
+                if arg_entry.source_names is not None
+                else None
+            ),
+        )
     return param, saved, saved is not None
 
 

--- a/src/liminate/interpreter.py
+++ b/src/liminate/interpreter.py
@@ -43,6 +43,7 @@ from .vocabulary import (
     CompareValuesExecution,
     DecayingValue,
     NumericExtractCompareExecution,
+    RangeCheckExecution,
     SetFieldExecution,
     SetValueExecution,
     SubstringCheckExecution,
@@ -795,6 +796,8 @@ def _exec_pack_verb(
         return _exec_pack_compare_values(node, execution, symtab)
     if isinstance(execution, NumericExtractCompareExecution):
         return _exec_pack_numeric_extract_compare(node, execution, symtab)
+    if isinstance(execution, RangeCheckExecution):
+        return _exec_pack_range_check(node, execution, symtab)
     raise _RuntimeError(
         f"Pack verb '{node.word}' has an unrecognized execution type."
     )
@@ -1078,6 +1081,112 @@ def _exec_pack_numeric_extract_compare(
                 "closest": closest,
                 "delta": delta,
                 "tolerance": tolerance,
+                "against_name": against_name,
+            },
+        )
+    return []
+
+
+def _range_number(text: str) -> int | float:
+    """Convert an extracted numeric token: int when it has no decimal point,
+    float otherwise (D-8)."""
+    return float(text) if "." in text else int(text)
+
+
+def _extract_range(text: str) -> tuple[int | float, int | float] | None:
+    """Extract the first two numbers from `text` as a (low, high) pair, using
+    the same regex `numeric_extract_compare` uses. Returns None when fewer
+    than two numbers are present (a parse error)."""
+    found = re.findall(r'-?\d+\.?\d*', text)
+    if len(found) < 2:
+        return None
+    return (_range_number(found[0]), _range_number(found[1]))
+
+
+def _exec_pack_range_check(
+    node: PackVerbNode,
+    execution: RangeCheckExecution,
+    symtab: dict[str, SymbolEntry],
+) -> list[str]:
+    """Seventh execution type (D-8): extract a (low, high) pair from a claimed
+    range string and a reference window string, compare them exactly, and
+    report which endpoints diverge. Non-match (mismatch or parse_error)
+    surfaces as PACK_VERB_FAILURE, with all four outputs stored first."""
+    check_node = node.slot_values.get(execution.check_slot)
+    against_node = node.slot_values.get(execution.against_slot)
+
+    claimed_text = _evaluate_expression(check_node, symtab, None)
+    reference_text = _evaluate_expression(against_node, symtab, None)
+    if not isinstance(claimed_text, str):
+        claimed_text = _format_scalar(claimed_text)
+    if not isinstance(reference_text, str):
+        reference_text = _format_scalar(reference_text)
+
+    against_name = (
+        against_node.name if isinstance(against_node, NameRef)
+        else execution.against_slot
+    )
+
+    claimed = _extract_range(claimed_text)
+    reference = _extract_range(reference_text)
+
+    def _fmt_range(pair) -> str:
+        if pair is None:
+            return "none"
+        return f"{_format_scalar(pair[0])} to {_format_scalar(pair[1])}"
+
+    # Parse error: fewer than two numbers in either string. Store outputs,
+    # then raise (non-match → PACK_VERB_FAILURE, Invariant-readiness).
+    if claimed is None or reference is None:
+        _store(symtab, execution.status_target, "parse_error")
+        _store(symtab, execution.claimed_target, _fmt_range(claimed))
+        _store(symtab, execution.reference_target, _fmt_range(reference))
+        _store(symtab, execution.divergence_target, "none")
+        which = "the claimed value" if claimed is None else f"'{against_name}'"
+        raise _PackVerbFailure(
+            f"Could not extract a numeric range from {which} — "
+            f"two numbers are required.",
+            metadata={
+                "verb": node.word,
+                "failure_type": "parse_error",
+                "against_name": against_name,
+            },
+        )
+
+    c_low, c_high = claimed
+    r_low, r_high = reference
+    claimed_str = _fmt_range(claimed)
+    reference_str = _fmt_range(reference)
+
+    low_diff = c_low != r_low
+    high_diff = c_high != r_high
+    if low_diff and high_diff:
+        divergence = "both"
+    elif low_diff:
+        divergence = "lower"
+    elif high_diff:
+        divergence = "upper"
+    else:
+        divergence = "none"
+
+    status = "match" if divergence == "none" else "mismatch"
+    _store(symtab, execution.status_target, status)
+    _store(symtab, execution.claimed_target, claimed_str)
+    _store(symtab, execution.reference_target, reference_str)
+    _store(symtab, execution.divergence_target, divergence)
+
+    # Invariant-readiness: a mismatch surfaces as PACK_VERB_FAILURE regardless
+    # of on_mismatch mode (mirrors numeric_extract_compare). Writes stay.
+    if status != "match":
+        raise _PackVerbFailure(
+            f"Claimed range {claimed_str} does not match '{against_name}' "
+            f"({reference_str}) — divergence: {divergence}.",
+            metadata={
+                "verb": node.word,
+                "failure_type": "range_mismatch",
+                "claimed": claimed_str,
+                "reference": reference_str,
+                "divergence": divergence,
                 "against_name": against_name,
             },
         )

--- a/src/liminate/listener.py
+++ b/src/liminate/listener.py
@@ -279,6 +279,17 @@ class _Runner:
             cascade_chain=frozenset(),
         )
 
+        # D-7 — metabolic decay advances once per `tick`-named update. This
+        # runs AFTER the normal cascade for the tick has completed, so
+        # handlers watching `tick` fire on the tick change first, then decay
+        # advances, then any handlers whose conditions changed due to decay
+        # fire in tick_decay's own cascade pass. The exact-name guard means
+        # no other adapter update triggers decay (§6 invariant 4).
+        if update.name == "tick":
+            yield from self.tick_decay()
+            if self.finish_requested:
+                return
+
     # -------------------------------------------------------------------
     # Eligibility, firing, cascade (§113, §114, §115)
     # -------------------------------------------------------------------

--- a/src/liminate/parser.py
+++ b/src/liminate/parser.py
@@ -382,11 +382,13 @@ class EachNode(ASTNode):
 @dataclass
 class CompositionCallNode(ASTNode):
     name: str
-    # v2d §96 — optional parameter-passing argument. None when the call
-    # provided no `from <name>` clause. The argument is always a name
-    # reference (names-only per §96); literal values are rejected at
-    # parse time.
-    arg: str | None = None
+    # v2d §96 / Phase 2 D-1 — optional parameter-passing argument. None when
+    # the call provided no `from <arg>` clause. A `str` is a bare-name
+    # reference resolved against the symbol table at run time (the v2d §96
+    # path). An `ASTNode` is a self-contained literal atom — `NumberLiteral`
+    # or `QuotedString` (D-1). Every reader (parser, analyzer, interpreter,
+    # renderer) must branch on `isinstance(arg, str)` before a symtab lookup.
+    arg: "str | ASTNode | None" = None
     rationale: str | None = field(default=None, compare=False)
     # Meta-Structural Era batch 3 — `inherited` operator + `from`
     # attribution. Both are inert provenance metadata (compare=False),
@@ -3241,11 +3243,17 @@ def _consume_target(stream: TokenStream, *, verb: str) -> NameRef:
     return NameRef(name=tok.value)
 
 
-def _consume_parameter_arg(stream: TokenStream, *, comp_name: str) -> str:
-    """v2d §96 — consume the name token that follows `<comp> from` at a
-    call site. Names-only: NUMBER / QUOTED_STRING / reserved words are
-    rejected here at parse time. The actual symbol lookup happens at run
-    time, consistent with v1's name-resolution timing (inception §23).
+def _consume_parameter_arg(stream: TokenStream, *, comp_name: str) -> str | ASTNode:
+    """Phase 2 D-1 — consume the argument token that follows `<comp> from`
+    at a call site. Atoms only: a bare name (UNKNOWN → symbol-table name,
+    returned as a string for the existing lookup path), a numeric literal
+    (NUMBER → `NumberLiteral`), or a quoted string (QUOTED_STRING →
+    `QuotedString`). Reserved words and end-of-line are rejected. No full
+    value expressions — no arithmetic, no `of` field access.
+
+    Returning `str` preserves the v2d §96 names-only path verbatim; the
+    AST-node returns are the new literal path. Name lookup still happens at
+    run time, consistent with v1's name-resolution timing (inception §23).
     """
     tok = stream.consume()
     if tok is None:
@@ -3253,11 +3261,10 @@ def _consume_parameter_arg(stream: TokenStream, *, comp_name: str) -> str:
             f"I expected a name after '{comp_name} from' — "
             f"compositions take a single name as input."
         )
+    if tok.type is TokenType.NUMBER:
+        return NumberLiteral(value=_parse_number(tok.value))
     if tok.type is TokenType.QUOTED_STRING:
-        raise _ParseError(
-            f"Names can't have spaces. Try a hyphenated name like "
-            f"'{_hyphenate(tok.value)}' instead."
-        )
+        return QuotedString(content=tok.value)
     if tok.type is not TokenType.UNKNOWN:
         cat = reserved_category(tok.value)
         if cat:

--- a/src/liminate/renderer.py
+++ b/src/liminate/renderer.py
@@ -236,8 +236,15 @@ def _render_node(node: ASTNode) -> str:
         return f"each the {render(node.collection)} {render(node.action)}"
 
     if isinstance(node, CompositionCallNode):
-        # v2d §96: parameter-passing call form.
+        # v2d §96 / Phase 2 D-1: parameter-passing call form. A bare-name
+        # arg (str) renders verbatim; a NumberLiteral renders as its number;
+        # a QuotedString ALWAYS renders with quotes — rendering it bare would
+        # re-parse as a name reference, not a literal, breaking round-trip.
         if node.arg is not None:
+            if isinstance(node.arg, NumberLiteral):
+                return f"{node.name} from {_fmt_number(node.arg.value)}"
+            if isinstance(node.arg, QuotedString):
+                return f'{node.name} from "{node.arg.content}"'
             return f"{node.name} from {node.arg}"
         return node.name
     if isinstance(node, ChooseNode):

--- a/src/liminate/run.py
+++ b/src/liminate/run.py
@@ -27,7 +27,7 @@ from datetime import datetime, timezone
 from typing import Any, Callable
 
 from .adapter import DomainPack, LiveValueRegistry
-from .analyzer import SymbolEntry
+from .analyzer import SymbolEntry, detect_contradictions
 from .interpreter import HandlerTable, execute
 from .lexer import LexError, leading_indent, tokenize
 from .listener import listen
@@ -394,6 +394,50 @@ def _consume_when_block(
 
 
 # ---------------------------------------------------------------------------
+# Phase 2 D-4 — contradiction pre-pass
+# ---------------------------------------------------------------------------
+
+
+def _collect_deontic_statements(lines: list[str]) -> list:
+    """Best-effort pre-pass: parse every top-level `require` / `forbid`
+    statement into an AST so contradiction detection can run once over the
+    whole program before execution.
+
+    Only indent-0 lines whose first token is the `require` or `forbid` verb
+    are parsed — this naturally excludes `when`-block action lines (indented)
+    and every non-deontic statement, and means a line that needs runtime
+    context (compositions, packs) is never parsed here. Anything that fails
+    to tokenize/reorder/parse is silently skipped: this pass is advisory and
+    must never introduce an error the main loop wouldn't also produce.
+    """
+    asts: list = []
+    for line in lines:
+        stripped = line.lstrip()
+        if not stripped or stripped.startswith("--"):
+            continue
+        try:
+            if leading_indent(line) != 0:
+                continue
+            toks = tokenize(line)
+        except LexError:
+            continue
+        if not (
+            toks
+            and toks[0].type is TokenType.VERB
+            and toks[0].value in ("require", "forbid")
+        ):
+            continue
+        reordered = reorder(toks)
+        if isinstance(reordered, LiminateResult):
+            continue
+        ast = parse(reordered)
+        if isinstance(ast, LiminateResult):
+            continue
+        asts.append(ast)
+    return asts
+
+
+# ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------
 
@@ -483,6 +527,20 @@ def run(
         session.record_result(result)
 
     lines = source.splitlines()
+
+    # Phase 2 D-4 — run contradiction detection once over the whole program
+    # before execution, so a warning surfaces even if a later `require`/`forbid`
+    # halts the run before reaching the conflicting statement. Warning-only:
+    # emitted as an informational SUCCESS result, never blocks execution and
+    # never sets had_error.
+    contradiction_warnings = detect_contradictions(_collect_deontic_statements(lines))
+    if contradiction_warnings:
+        warn_result = LiminateResult(
+            status=ResultStatus.SUCCESS,
+            output=[f"⚠ {w}" for w in contradiction_warnings],
+            executed=False,
+        )
+        _emit(warn_result, None, None, None)
 
     # Meta-Structural Era: track whether the first eligible (non-blank,
     # non-comment) line has been seen, so `about` is recognized only as

--- a/src/liminate/vocabulary.py
+++ b/src/liminate/vocabulary.py
@@ -393,6 +393,17 @@ class NumericExtractCompareExecution:
     delta_target: str        # symbol name for the absolute difference
 
 
+@dataclass(frozen=True)
+class RangeCheckExecution:
+    check_slot: str          # slot containing the claimed range (string)
+    against_slot: str        # slot containing the reference window (string)
+    on_mismatch: str         # "error" | "flag"
+    status_target: str       # symbol name for "match" / "mismatch" / "parse_error"
+    claimed_target: str      # symbol name for extracted (low, high) string
+    reference_target: str    # symbol name for extracted (low, high) string
+    divergence_target: str   # symbol name for "lower" / "upper" / "both" / "none"
+
+
 PackVerbExecution = (
     SetValueExecution
     | SubstringCheckExecution
@@ -400,6 +411,7 @@ PackVerbExecution = (
     | SetFieldExecution
     | CompareValuesExecution
     | NumericExtractCompareExecution
+    | RangeCheckExecution
 )
 
 

--- a/tests/test_composition_param_literals.py
+++ b/tests/test_composition_param_literals.py
@@ -1,0 +1,264 @@
+"""Phase 2 D-1 — composition parameters accept literal values.
+
+Compositions may now be called with a numeric literal or a quoted-string
+literal as the single parameter argument, alongside the existing bare-name
+form. Literals are self-contained atoms: no symbol-table lookup, no
+arithmetic, no `of` field access. Bare names keep their v2d §96 semantics.
+"""
+
+from liminate.cli import Session
+from liminate.parser import (
+    CompositionCallNode,
+    NumberLiteral,
+    QuotedString,
+    parse,
+)
+from liminate.lexer import tokenize
+from liminate.renderer import render
+from liminate.result import LiminateResult, ResultStatus
+
+
+def run_lines(lines):
+    session = Session()
+    results = [session.run_line(line) for line in lines]
+    return session, results
+
+
+def parse_line(line, comps=None):
+    # Parse directly (no reorderer) so parser-level rejection paths — e.g. a
+    # reserved word as an argument — are reached as units, matching
+    # tests/test_parser.py. The reorderer would otherwise intercept a leading
+    # verb token before the parser sees it.
+    return parse(tokenize(line), composition_names=comps or set())
+
+
+# ---------------------------------------------------------------------------
+# 1–3, 14 — literal params execute correctly through the full pipeline
+# ---------------------------------------------------------------------------
+
+
+def test_numeric_literal_parameter_used_in_body():
+    """1. `find-big from 50` — numeric literal bound to the param, the
+    composition body references it as a threshold."""
+    session, results = run_lines([
+        "remember an order called o1 with total as 75 and status as active",
+        "remember an order called o2 with total as 30 and status as pending",
+        "remember a list called orders with o1 and o2",
+        "remember how to find-big from limit: keep the orders where total is above limit",
+        "find-big from 50",
+    ])
+    assert all(r.status is ResultStatus.SUCCESS for r in results)
+    assert results[4].output == ["total: 75, status: active"]
+
+
+def test_quoted_string_literal_parameter_used_in_body():
+    """2. `find-status from "in progress"` — multi-word quoted-string literal
+    bound to the param and compared inside the body."""
+    session, results = run_lines([
+        'remember an order called o1 with total as 75 and status as "in progress"',
+        "remember an order called o2 with total as 30 and status as pending",
+        "remember a list called orders with o1 and o2",
+        "remember how to find-status from wanted: keep the orders where status is wanted",
+        'find-status from "in progress"',
+    ])
+    assert all(r.status is ResultStatus.SUCCESS for r in results)
+    assert results[4].output == ["total: 75, status: in progress"]
+
+
+def test_float_literal_parameter():
+    """3. `find-big from 3.14` — a float literal parses to NumberLiteral(3.14)
+    and binds as a number."""
+    ast = parse_line("find-big from 3.14", comps={"find-big"})
+    assert isinstance(ast, CompositionCallNode)
+    assert ast.arg == NumberLiteral(value=3.14)
+    # And it executes: keep orders whose total exceeds 3.14 (both match).
+    session, results = run_lines([
+        "remember an order called o1 with total as 75 and status as active",
+        "remember an order called o2 with total as 30 and status as pending",
+        "remember a list called orders with o1 and o2",
+        "remember how to find-big from limit: keep the orders where total is above limit",
+        "find-big from 3.14",
+    ])
+    assert results[4].status is ResultStatus.SUCCESS
+    assert results[4].output == ["total: 75, status: active", "total: 30, status: pending"]
+
+
+def test_body_references_param_bound_to_literal_via_show():
+    """14. Body that directly shows the literal-bound param."""
+    session, results = run_lines([
+        "remember how to echo from x: show x",
+        "echo from 42",
+    ])
+    assert results[1].status is ResultStatus.SUCCESS
+    assert results[1].output == ["42"]
+
+
+# ---------------------------------------------------------------------------
+# 4–7 — regressions: bare names + parameter/argument arity rules
+# ---------------------------------------------------------------------------
+
+
+def test_bare_name_parameter_still_works():
+    """4. `find-big from orders` — bare-name argument, the v2d §96 path."""
+    ast = parse_line("find-big from orders", comps={"find-big"})
+    assert isinstance(ast, CompositionCallNode)
+    assert ast.arg == "orders"  # a plain string, not an AST node
+    session, results = run_lines([
+        "remember an order called o1 with total as 75 and status as active",
+        "remember an order called o2 with total as 30 and status as pending",
+        "remember a list called orders with o1 and o2",
+        "remember how to find-big from data: keep the data where total is above 50",
+        "find-big from orders",
+    ])
+    assert results[4].status is ResultStatus.SUCCESS
+    assert results[4].output == ["total: 75, status: active"]
+
+
+def test_composition_without_parameter_still_works():
+    """5. A parameter-less composition is still callable bare."""
+    session, results = run_lines([
+        "remember a list called nums with 1 and 2 and 3",
+        "remember how to tally: count the nums",
+        "tally",
+    ])
+    assert results[2].status is ResultStatus.SUCCESS
+    assert results[2].output == ["3"]
+
+
+def test_parameter_expected_but_no_argument_errors():
+    """6. Composition declares a param; the call provides none."""
+    session, results = run_lines([
+        "remember how to find-big from data: keep the data where total is above 50",
+        "find-big",
+    ])
+    assert results[1].status is ResultStatus.ERROR_SEMANTIC
+    assert "expects an input" in results[1].message
+
+
+def test_no_parameter_but_argument_supplied_errors():
+    """7. Composition declares no param; the call supplies one."""
+    session, results = run_lines([
+        "remember a list called nums with 1 and 2 and 3",
+        "remember how to tally: count the nums",
+        "tally from 50",
+    ])
+    assert results[2].status is ResultStatus.ERROR_SEMANTIC
+    assert "doesn't take an input" in results[2].message
+
+
+# ---------------------------------------------------------------------------
+# 8 — literal param in a value-position (capturing) composition call
+# ---------------------------------------------------------------------------
+
+
+def test_literal_param_in_value_position_call():
+    """8. `remember ... from <comp> from 50` — captures the return value of
+    a parameterized call whose argument is a literal (two `from` tokens)."""
+    session, results = run_lines([
+        "remember an order called o1 with total as 75 and status as active",
+        "remember an order called o2 with total as 30 and status as pending",
+        "remember a list called orders with o1 and o2",
+        "remember how to find-big from limit: keep the orders where total is above limit",
+        "remember the results called big from find-big from 50",
+        "count big",
+    ])
+    assert results[4].status is ResultStatus.SUCCESS
+    assert results[5].output == ["1"]
+    assert len(session.symtab["big"].value) == 1
+    assert session.symtab["big"].value[0]["total"] == 75
+
+
+# ---------------------------------------------------------------------------
+# 9–10 — canonical rendering of literal-param calls
+# ---------------------------------------------------------------------------
+
+
+def test_render_numeric_literal_parameter_call():
+    """9. Numeric literal renders as the bare number."""
+    node = CompositionCallNode(name="check-threshold", arg=NumberLiteral(value=50))
+    assert render(node) == "check-threshold from 50"
+    node_f = CompositionCallNode(name="check-threshold", arg=NumberLiteral(value=3.14))
+    assert render(node_f) == "check-threshold from 3.14"
+
+
+def test_render_quoted_string_literal_parameter_call():
+    """10. Quoted-string literal ALWAYS renders with quotes so it round-trips
+    back to a literal rather than a name reference."""
+    node = CompositionCallNode(name="check-status", arg=QuotedString(content="in progress"))
+    assert render(node) == 'check-status from "in progress"'
+    # Even a single-word string keeps its quotes (round-trip integrity).
+    node1 = CompositionCallNode(name="check-status", arg=QuotedString(content="active"))
+    assert render(node1) == 'check-status from "active"'
+
+
+def test_render_roundtrip_quoted_literal_stays_literal():
+    """Re-parsing rendered output preserves the QuotedString (not a name)."""
+    node = CompositionCallNode(name="check-status", arg=QuotedString(content="active"))
+    reparsed = parse_line(render(node), comps={"check-status"})
+    assert isinstance(reparsed, CompositionCallNode)
+    assert reparsed.arg == QuotedString(content="active")
+
+
+# ---------------------------------------------------------------------------
+# 11–12 — rejection regressions: reserved words and end-of-line
+# ---------------------------------------------------------------------------
+
+
+def test_reserved_word_after_from_errors():
+    """11. A reserved word is still rejected as an argument."""
+    out = parse_line("find-big from filter", comps={"find-big"})
+    assert isinstance(out, LiminateResult)
+    assert out.status is ResultStatus.ERROR_PARSE
+    assert "reserved" in out.message
+
+
+def test_end_of_line_after_from_errors():
+    """12. `<comp> from` with nothing after it is still an error."""
+    out = parse_line("find-big from", comps={"find-big"})
+    assert isinstance(out, LiminateResult)
+    assert out.status is ResultStatus.ERROR_PARSE
+    assert "expected a name" in out.message
+
+
+# ---------------------------------------------------------------------------
+# 13 — shadowing: literal param shadows a global, original restored after
+# ---------------------------------------------------------------------------
+
+
+def test_literal_param_shadows_global_and_restores():
+    """13. A global named the same as the param is shadowed by the literal
+    for the duration of the call, then restored."""
+    session, results = run_lines([
+        "remember a value called limit with 999",
+        "remember an order called o1 with total as 75 and status as active",
+        "remember an order called o2 with total as 30 and status as pending",
+        "remember a list called orders with o1 and o2",
+        "remember how to find-big from limit: keep the orders where total is above limit",
+        "find-big from 50",
+        "show limit",
+    ])
+    # The call used the literal 50 as the threshold (only o1 qualifies)...
+    assert results[5].output == ["total: 75, status: active"]
+    # ...and the global `limit` (999) is restored afterward.
+    assert results[6].output == ["999"]
+    assert session.symtab["limit"].value == 999
+
+
+# ---------------------------------------------------------------------------
+# 15 — nested composition call with a literal param
+# ---------------------------------------------------------------------------
+
+
+def test_nested_composition_call_with_literal_param():
+    """15. A composition body that itself calls another composition with a
+    literal argument."""
+    session, results = run_lines([
+        "remember an order called o1 with total as 75 and status as active",
+        "remember an order called o2 with total as 30 and status as pending",
+        "remember a list called orders with o1 and o2",
+        "remember how to big-ones from threshold: keep the orders where total is above threshold",
+        "remember how to standard: big-ones from 50",
+        "standard",
+    ])
+    assert all(r.status is ResultStatus.SUCCESS for r in results)
+    assert results[5].output == ["total: 75, status: active"]

--- a/tests/test_contradiction_detection.py
+++ b/tests/test_contradiction_detection.py
@@ -1,0 +1,189 @@
+"""Phase 2 D-4 — analyzer-time deontic contradiction detection.
+
+`detect_contradictions` is a static, warning-only pass over the top-level
+ASTs of a program. It reports direct same-field logical conflicts between
+`require` / `forbid` statements with simple (single-leaf) conditions. It
+never blocks execution and never changes a result status.
+"""
+
+from liminate.analyzer import detect_contradictions
+from liminate.cli import Session
+from liminate.lexer import tokenize
+from liminate.parser import parse
+from liminate.reorderer import reorder
+from liminate.result import LiminateResult, ResultStatus
+
+
+def _parse(line):
+    reordered = reorder(tokenize(line))
+    assert not isinstance(reordered, LiminateResult), line
+    ast = parse(reordered)
+    assert not isinstance(ast, LiminateResult), line
+    return ast
+
+
+def warnings_for(lines):
+    return detect_contradictions([_parse(l) for l in lines])
+
+
+def run_lines(lines):
+    session = Session()
+    results = [session.run_line(line) for line in lines]
+    return session, results
+
+
+# ---------------------------------------------------------------------------
+# 1–7 — the contradiction-rule table
+# ---------------------------------------------------------------------------
+
+
+def test_require_above_and_forbid_above_same_value_warns():
+    """1. Rule 1 — identical operator+value, require vs forbid."""
+    w = warnings_for(["require X is above 50", "forbid X is above 50"])
+    assert len(w) == 1
+    assert "contradiction" in w[0].lower()
+
+
+def test_require_above_and_require_below_empty_range_warns():
+    """2. Rule 2 — `above 50` and `below 30` leave no satisfying value."""
+    w = warnings_for(["require X is above 50", "require X is below 30"])
+    assert len(w) == 1
+
+
+def test_require_above_and_require_below_satisfiable_range_no_warning():
+    """3. `above 50` and `below 80` are jointly satisfiable — no warning."""
+    w = warnings_for(["require X is above 50", "require X is below 80"])
+    assert w == []
+
+
+def test_require_equals_and_forbid_equals_same_value_warns():
+    """4. Rule 1/3 — equality require vs equality forbid, same value."""
+    w = warnings_for(["require X is value1", "forbid X is value1"])
+    assert len(w) == 1
+
+
+def test_require_equals_two_different_values_warns():
+    """5. Rule 4 — two equality requirements with different values."""
+    w = warnings_for(["require X is value1", "require X is value2"])
+    assert len(w) == 1
+
+
+def test_two_forbids_both_satisfiable_no_warning():
+    """6. `forbid above 50` + `forbid below 30` — X in [30,50] satisfies both
+    (rules 2 and 4 are require+require only)."""
+    w = warnings_for(["forbid X is above 50", "forbid X is below 30"])
+    assert w == []
+
+
+def test_permit_never_contradicts():
+    """7. `permit` is informational and never participates."""
+    w = warnings_for(["require X is above 50", "permit X is above 50"])
+    assert w == []
+
+
+# ---------------------------------------------------------------------------
+# 8–9 — trivial cases
+# ---------------------------------------------------------------------------
+
+
+def test_no_deontic_statements_no_warnings():
+    """8. A program with no require/forbid produces no warnings."""
+    w = warnings_for([
+        "remember a number called X with 5",
+        "show X",
+    ])
+    assert w == []
+
+
+def test_single_require_no_warnings():
+    """9. One requirement cannot contradict anything."""
+    w = warnings_for(["require X is above 50"])
+    assert w == []
+
+
+# ---------------------------------------------------------------------------
+# 10–11 — scope boundaries
+# ---------------------------------------------------------------------------
+
+
+def test_compound_condition_leaves_not_detected():
+    """10. Compound (`and`/`or`) conditions are out of scope — even with
+    contradicting leaves, no warning is emitted."""
+    w = warnings_for([
+        "require X is above 50 and X is below 30",
+        "forbid X is above 50 and X is below 30",
+    ])
+    assert w == []
+
+
+def test_different_fields_no_warning():
+    """11. A conflict only exists when both statements target the same field."""
+    w = warnings_for(["require X is above 50", "forbid Y is above 50"])
+    assert w == []
+
+
+# ---------------------------------------------------------------------------
+# Extra coverage of the rule table (spec §3 design table rows)
+# ---------------------------------------------------------------------------
+
+
+def test_require_above_and_forbid_above_different_value_no_warning():
+    """`require above 50` + `forbid above 80` — X in (50,80] satisfies both."""
+    w = warnings_for(["require X is above 50", "forbid X is above 80"])
+    assert w == []
+
+
+def test_equality_via_is_equal_to_normalizes():
+    """`is equal to` and bare `is` both mean equality (normalized)."""
+    w = warnings_for(["require X is equal to 50", "forbid X is 50"])
+    assert len(w) == 1
+
+
+def test_quoted_string_equality_contradiction():
+    """Quoted-string equality values participate like barewords."""
+    w = warnings_for(['require X is "open"', 'forbid X is "open"'])
+    assert len(w) == 1
+
+
+def test_warning_names_both_statements_and_field():
+    """The message identifies both statements and the shared field."""
+    w = warnings_for(["require X is above 50", "forbid X is above 50"])
+    assert "require x is above 50" in w[0]
+    assert "forbid x is above 50" in w[0]
+    assert "x" in w[0]
+
+
+# ---------------------------------------------------------------------------
+# 12 — integration: warning surfaces, execution is not blocked
+# ---------------------------------------------------------------------------
+
+
+def test_integration_contradiction_warns_without_blocking_execution():
+    """12. A full program with a contradiction runs to completion; the
+    warning appears in the output and execution is not halted by it."""
+    session, results = run_lines([
+        "remember a number called X with 99",
+        "require X is above 50",
+        "forbid X is above 80",
+        "show X",
+    ])
+    # Without a contradiction the program would run identically; here we only
+    # assert nothing was blocked by the analysis pass itself.
+    assert results[0].status is ResultStatus.SUCCESS
+
+    # Drive the same program through the whole-program loop to see the warning.
+    from liminate.run import run as run_program
+    source = "\n".join([
+        "remember a number called X with 99",
+        "require X is above 50",
+        "forbid X is above 50",
+        "show X",
+    ])
+    contract = run_program(source, enter_phase2=False)
+    outputs = [line for r in contract.results if r and r.output for line in r.output]
+    assert any(line.startswith("⚠") and "contradiction" in line.lower()
+               for line in outputs)
+    # `show X` still executed — execution was not blocked by the warning.
+    assert any(line == "99" for line in outputs)
+    # The advisory pass itself does not flip had_error.
+    assert contract.results[0].status is ResultStatus.SUCCESS

--- a/tests/test_decay_tick_adapter.py
+++ b/tests/test_decay_tick_adapter.py
@@ -1,0 +1,261 @@
+"""Phase 4 D-7 — timer-driven decay.
+
+The listener advances metabolic decay (`weakens X over N`) once per
+`tick`-named adapter update, after the normal handler cascade for that tick
+completes. No other adapter update triggers decay. Tests drive the listener
+deterministically with a scripted TestDomainPack rather than the threaded
+timer pack.
+"""
+
+from __future__ import annotations
+
+from liminate.adapter import TestDomainPack
+from liminate.result import ResultStatus
+from liminate.vocabulary import DecayingValue
+
+from tests._v3a_helpers import run_v3a
+
+
+def _tick_pack(n_ticks: int, *, extra_decls=None):
+    """A TestDomainPack that emits `tick` updates valued 1..n_ticks."""
+    decls = [("tick", "number")]
+    if extra_decls:
+        decls.extend(extra_decls)
+    return TestDomainPack(
+        declarations=decls,
+        script=[("tick", i) for i in range(1, n_ticks + 1)],
+    )
+
+
+def _outputs(results):
+    return [line for r in results if r and r.output for line in r.output]
+
+
+# ---------------------------------------------------------------------------
+# 1–2 — decay advances on each tick
+# ---------------------------------------------------------------------------
+
+
+def test_decay_reaches_zero_over_its_period():
+    """1. `weakens trust over 5` with 5 ticks decays trust to 0."""
+    session, _ = run_v3a(
+        """
+        remember a number called trust with 100
+        weakens trust over 5
+        when trust is below 1
+          show "gone"
+        """,
+        pack=_tick_pack(5),
+    )
+    decaying = session.symtab["trust"].value
+    assert isinstance(decaying, DecayingValue)
+    assert decaying.ticks_elapsed == 5
+    assert decaying.current_value == 0.0
+
+
+def test_decay_is_linear_per_tick():
+    """2. After 3 of 5 ticks, trust is at 40% of its initial value."""
+    session, _ = run_v3a(
+        """
+        remember a number called trust with 100
+        weakens trust over 5
+        when trust is below 1
+          show "gone"
+        """,
+        pack=_tick_pack(3),
+    )
+    decaying = session.symtab["trust"].value
+    assert decaying.ticks_elapsed == 3
+    assert decaying.current_value == 40.0
+
+
+# ---------------------------------------------------------------------------
+# 3 — a when handler fires on decay
+# ---------------------------------------------------------------------------
+
+
+def test_handler_fires_when_decay_crosses_threshold():
+    """3. `when trust is below 50` fires once decay brings trust under 50
+    (at tick 3: 100 → 40)."""
+    session, results = run_v3a(
+        """
+        remember a number called trust with 100
+        weakens trust over 5
+        when trust is below 50
+          show "trust low"
+        """,
+        pack=_tick_pack(5),
+    )
+    fires = [r for r in results if r.status is ResultStatus.HANDLER_FIRE]
+    assert fires
+    assert any("trust low" in line for line in _outputs(results))
+
+
+# ---------------------------------------------------------------------------
+# 4 — non-tick updates do not advance decay
+# ---------------------------------------------------------------------------
+
+
+def test_non_tick_update_does_not_advance_decay():
+    """4. A `temperature` update from another source must not tick decay."""
+    pack = TestDomainPack(
+        declarations=[("tick", "number"), ("temperature", "number")],
+        script=[("temperature", 20), ("temperature", 21)],
+    )
+    session, _ = run_v3a(
+        """
+        remember a number called trust with 100
+        weakens trust over 5
+        when temperature is above 100
+          show "hot"
+        """,
+        pack=pack,
+    )
+    decaying = session.symtab["trust"].value
+    assert decaying.ticks_elapsed == 0
+    assert decaying.current_value == 100.0
+
+
+# ---------------------------------------------------------------------------
+# 5 — multiple decaying values advance together
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_decaying_values_advance_each_tick():
+    """5. Two decaying values with different periods both advance per tick."""
+    session, _ = run_v3a(
+        """
+        remember a number called trust with 100
+        remember a number called confidence with 100
+        weakens trust over 5
+        weakens confidence over 10
+        when trust is below 1
+          show "gone"
+        """,
+        pack=_tick_pack(5),
+    )
+    trust = session.symtab["trust"].value
+    confidence = session.symtab["confidence"].value
+    assert trust.ticks_elapsed == 5
+    assert confidence.ticks_elapsed == 5
+    assert trust.current_value == 0.0       # 100 - 20*5
+    assert confidence.current_value == 50.0  # 100 - 10*5
+
+
+# ---------------------------------------------------------------------------
+# 6 — reinforcement mid-decay resets
+# ---------------------------------------------------------------------------
+
+
+def test_reinforcement_mid_decay_resets():
+    """6. Re-remembering trust in a tick-3 handler reinforces (resets) the
+    decay in place. The handler fires before that tick's decay advance, so
+    after the reset ticks 3, 4 and 5 each advance decay once."""
+    session, results = run_v3a(
+        """
+        remember a number called trust with 100
+        weakens trust over 5
+        when tick is equal to 3
+          remember a number called trust with 100
+        """,
+        pack=_tick_pack(5),
+    )
+    decaying = session.symtab["trust"].value
+    # Reset (ticks_elapsed → 0) happened inside tick 3, before its decay
+    # advance; ticks 3, 4 and 5 then advanced decay → ticks_elapsed == 3.
+    assert isinstance(decaying, DecayingValue)
+    assert decaying.initial_value == 100.0
+    assert decaying.ticks_elapsed == 3
+    assert decaying.current_value == 40.0  # 100 - 20*3
+
+
+# ---------------------------------------------------------------------------
+# 7 — finish during a decay-triggered handler stops cleanly
+# ---------------------------------------------------------------------------
+
+
+def test_finish_during_decay_handler_stops_listener():
+    """7. `finish` inside a handler that fired due to decay stops the
+    listener cleanly (a SHUTDOWN result, no errors)."""
+    session, results = run_v3a(
+        """
+        remember a number called trust with 100
+        weakens trust over 5
+        when trust is below 50
+          finish
+        """,
+        pack=_tick_pack(5),
+    )
+    assert any(r.status is ResultStatus.SHUTDOWN for r in results)
+    assert not any(
+        r.status in (ResultStatus.ERROR_RUNTIME, ResultStatus.ERROR_SEMANTIC)
+        for r in results
+    )
+
+
+# ---------------------------------------------------------------------------
+# 8 — no decaying values: tick_decay is a no-op
+# ---------------------------------------------------------------------------
+
+
+def test_no_decaying_values_is_noop():
+    """8. With no `weakens`, ticks fire handlers but tick_decay does nothing
+    and raises nothing."""
+    session, results = run_v3a(
+        """
+        remember a number called seen with 0
+        when tick is equal to 2
+          show "tick two"
+        """,
+        pack=_tick_pack(3),
+    )
+    assert any("tick two" in line for line in _outputs(results))
+    assert not any(
+        r.status in (ResultStatus.ERROR_RUNTIME, ResultStatus.ERROR_SEMANTIC)
+        for r in results
+    )
+
+
+# ---------------------------------------------------------------------------
+# 9 — decay reaching zero fires a watcher for zero
+# ---------------------------------------------------------------------------
+
+
+def test_decay_reaching_zero_fires_zero_watcher():
+    """9. A handler watching for the floor fires when decay hits 0."""
+    session, results = run_v3a(
+        """
+        remember a number called trust with 100
+        weakens trust over 5
+        when trust is equal to 0
+          show "depleted"
+        """,
+        pack=_tick_pack(5),
+    )
+    assert session.symtab["trust"].value.current_value == 0.0
+    assert any("depleted" in line for line in _outputs(results))
+
+
+# ---------------------------------------------------------------------------
+# 10 — full integration: scripted timer + decay + cascade
+# ---------------------------------------------------------------------------
+
+
+def test_integration_timer_decay_and_cascade():
+    """10. End to end: ticks drive decay, the decay crossing fires a handler,
+    and the listener shuts down normally."""
+    session, results = run_v3a(
+        """
+        remember a number called trust with 100
+        weakens trust over 4
+        when trust is below 50
+          show "below half"
+        """,
+        pack=_tick_pack(4),
+    )
+    statuses = [r.status for r in results]
+    assert ResultStatus.LISTENING in statuses
+    assert ResultStatus.HANDLER_FIRE in statuses
+    assert ResultStatus.SHUTDOWN in statuses
+    assert session.symtab["trust"].value.current_value == 0.0
+    assert any("below half" in line for line in _outputs(results))

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -499,10 +499,13 @@ def test_composition_call_without_parameter_argument():
     assert ast.arg is None
 
 
-def test_composition_call_arg_must_be_a_name_not_a_literal():
-    out = parse_line("find-big from 5", comps={"find-big"})
-    assert isinstance(out, LiminateResult)
-    assert out.status is ResultStatus.ERROR_PARSE
+def test_composition_call_arg_accepts_a_numeric_literal():
+    # Phase 2 D-1 supersedes the v2d §96 names-only restriction: composition
+    # parameters now accept numeric literals as a self-contained argument.
+    ast = parse_line("find-big from 5", comps={"find-big"})
+    assert isinstance(ast, CompositionCallNode)
+    assert ast.name == "find-big"
+    assert ast.arg == NumberLiteral(value=5)
 
 
 def test_composition_call_arg_must_be_a_name_not_a_reserved_word():

--- a/tests/test_range_check.py
+++ b/tests/test_range_check.py
@@ -1,0 +1,256 @@
+"""Phase 3 D-8 — the `range_check` execution type and the `validate` pack verb.
+
+`range_check` extracts a (low, high) pair from a claimed range string and a
+reference window string, compares them exactly, and reports which endpoints
+diverge. The research pack exposes it as the `validate` verb operating on
+`window`-typed symbols. A non-match (mismatch or parse_error) surfaces as
+PACK_VERB_FAILURE, with all four outputs stored before the raise.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from liminate.adapter import TestDomainPack, parse_pack_verb_signature
+from liminate.result import ResultStatus
+from liminate.vocabulary import RangeCheckExecution
+
+from tests._v3a_helpers import run_v3a
+
+
+def _load_research_pack() -> TestDomainPack:
+    path = (
+        Path(__file__).resolve().parent.parent
+        / "examples"
+        / "pack_research.json"
+    )
+    config = json.loads(path.read_text(encoding="utf-8"))
+    vocab = [
+        (e["word"], e.get("category", "noun"))
+        for e in config.get("vocabulary", [])
+    ]
+    verbs = [parse_pack_verb_signature(v) for v in config.get("verbs", [])]
+    return TestDomainPack(
+        declarations=[],
+        script=[],
+        name=config.get("name", "research"),
+        vocabulary=vocab,
+        verbs=verbs,
+    )
+
+
+def _run(claimed: str, window_text: str):
+    """Run `validate "<claimed>" from w` against a window holding window_text.
+    Returns (session, results)."""
+    src = (
+        f'remember a window called w with "{window_text}"\n'
+        f'validate "{claimed}" from w'
+    )
+    return run_v3a(src, pack=_load_research_pack())
+
+
+def _syms(session):
+    return {
+        k: session.symtab[k].value
+        for k in (
+            "range-status", "range-claimed",
+            "range-reference", "range-divergence",
+        )
+        if k in session.symtab
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1–5, 8–9 — comparison + divergence outcomes
+# ---------------------------------------------------------------------------
+
+
+def test_matching_ranges_with_surrounding_prose():
+    """1. `18 to 38` vs `ages 18 to 38` → match, divergence none."""
+    session, results = _run("18 to 38", "ages 18 to 38")
+    s = _syms(session)
+    assert s["range-status"] == "match"
+    assert s["range-divergence"] == "none"
+    assert s["range-claimed"] == "18 to 38"
+    assert s["range-reference"] == "18 to 38"
+
+
+def test_upper_mismatch():
+    """2. `18 to 36` vs `18 to 38` → mismatch, divergence upper."""
+    session, _ = _run("18 to 36", "18 to 38")
+    s = _syms(session)
+    assert s["range-status"] == "mismatch"
+    assert s["range-divergence"] == "upper"
+
+
+def test_lower_mismatch():
+    """3. `16 to 38` vs `18 to 38` → mismatch, divergence lower."""
+    session, _ = _run("16 to 38", "18 to 38")
+    s = _syms(session)
+    assert s["range-status"] == "mismatch"
+    assert s["range-divergence"] == "lower"
+
+
+def test_both_mismatch():
+    """4. `16 to 36` vs `18 to 38` → mismatch, divergence both."""
+    session, _ = _run("16 to 36", "18 to 38")
+    s = _syms(session)
+    assert s["range-status"] == "mismatch"
+    assert s["range-divergence"] == "both"
+
+
+def test_exact_match_with_prose_on_both_sides():
+    """5. `ages 18 to 38` vs `ages 18 to 38` → match."""
+    session, _ = _run("ages 18 to 38", "ages 18 to 38")
+    s = _syms(session)
+    assert s["range-status"] == "match"
+    assert s["range-divergence"] == "none"
+
+
+def test_float_ranges_match():
+    """8. `1.5 to 3.5` vs `1.5 to 3.5` → match (float endpoints)."""
+    session, _ = _run("1.5 to 3.5", "1.5 to 3.5")
+    s = _syms(session)
+    assert s["range-status"] == "match"
+    assert s["range-claimed"] == "1.5 to 3.5"
+
+
+def test_negative_numbers_match():
+    """9. `-10 to 10` vs `-10 to 10` → match (negative endpoints)."""
+    session, _ = _run("-10 to 10", "-10 to 10")
+    s = _syms(session)
+    assert s["range-status"] == "match"
+    assert s["range-claimed"] == "-10 to 10"
+
+
+# ---------------------------------------------------------------------------
+# 6–7 — parse errors
+# ---------------------------------------------------------------------------
+
+
+def test_parse_error_no_numbers():
+    """6. Reference with no numbers → parse_error."""
+    session, results = _run("18 to 36", "no numbers here")
+    s = _syms(session)
+    assert s["range-status"] == "parse_error"
+    assert any(r.status is ResultStatus.PACK_VERB_FAILURE for r in results)
+
+
+def test_parse_error_only_one_number():
+    """7. Only one number found → parse_error."""
+    session, results = _run("18 to 36", "just 18 alone")
+    s = _syms(session)
+    assert s["range-status"] == "parse_error"
+    assert any(r.status is ResultStatus.PACK_VERB_FAILURE for r in results)
+
+
+# ---------------------------------------------------------------------------
+# 10–11 — failure semantics + store-before-raise
+# ---------------------------------------------------------------------------
+
+
+def test_mismatch_raises_pack_verb_failure():
+    """10. A mismatch surfaces as PACK_VERB_FAILURE."""
+    _, results = _run("18 to 36", "18 to 38")
+    failures = [r for r in results if r.status is ResultStatus.PACK_VERB_FAILURE]
+    assert failures
+    assert "w" in failures[0].message
+
+
+def test_outputs_stored_before_failure_raises():
+    """11. All four symbol outputs are committed before the raise so handlers
+    can observe them."""
+    session, results = _run("16 to 36", "18 to 38")
+    s = _syms(session)
+    # Even though the verb raised, every output is present.
+    assert s["range-status"] == "mismatch"
+    assert s["range-claimed"] == "16 to 36"
+    assert s["range-reference"] == "18 to 38"
+    assert s["range-divergence"] == "both"
+
+
+# ---------------------------------------------------------------------------
+# 12–14 — pack loading + load-time validation
+# ---------------------------------------------------------------------------
+
+
+def test_validate_verb_loads_from_research_pack():
+    """12. The `validate` verb parses and exposes a RangeCheckExecution."""
+    pack = _load_research_pack()
+    verbs = {v.word: v for v in pack.verbs()}
+    assert "validate" in verbs
+    assert isinstance(verbs["validate"].execution, RangeCheckExecution)
+
+
+def test_validate_rejects_non_window_type_constraint():
+    """13. The `reference` slot's `window` type_constraint is enforced — a
+    non-window symbol is rejected."""
+    src = (
+        'remember a release called r with "ages 18 to 38"\n'
+        'validate "18 to 38" from r'
+    )
+    _, results = run_v3a(src, pack=_load_research_pack())
+    errors = [r for r in results if r.status is ResultStatus.ERROR_SEMANTIC]
+    assert errors
+    assert "window" in errors[0].message
+
+
+def test_range_check_load_time_validation_rules_pass():
+    """14. A well-formed range_check signature passes load-time validation,
+    and bad ones are rejected."""
+    base = {
+        "word": "validate",
+        "slots": [
+            {"name": "claimed", "connective": None, "required": True,
+             "value_type": "value"},
+            {"name": "reference", "connective": "from", "required": True,
+             "value_type": "name", "type_constraint": "window"},
+        ],
+        "execution": {
+            "type": "range_check",
+            "check_slot": "claimed",
+            "against_slot": "reference",
+            "on_mismatch": "flag",
+            "status_target": "range-status",
+            "claimed_target": "range-claimed",
+            "reference_target": "range-reference",
+            "divergence_target": "range-divergence",
+        },
+    }
+    sig = parse_pack_verb_signature(base)
+    assert isinstance(sig.execution, RangeCheckExecution)
+
+    # Bad on_mismatch is rejected.
+    bad_mode = json.loads(json.dumps(base))
+    bad_mode["execution"]["on_mismatch"] = "shrug"
+    with pytest.raises(ValueError, match="on_mismatch"):
+        parse_pack_verb_signature(bad_mode)
+
+    # Empty target is rejected.
+    bad_target = json.loads(json.dumps(base))
+    bad_target["execution"]["divergence_target"] = ""
+    with pytest.raises(ValueError, match="divergence_target"):
+        parse_pack_verb_signature(bad_target)
+
+
+# ---------------------------------------------------------------------------
+# 15 — integration
+# ---------------------------------------------------------------------------
+
+
+def test_integration_validate_surfaces_mismatch():
+    """15. A full program: a valid window, then a mismatching validate whose
+    failure surfaces correctly while outputs remain inspectable."""
+    src = (
+        'remember a window called coverage with "ages 18 to 38, May 2026"\n'
+        'validate "18 to 40" from coverage'
+    )
+    session, results = run_v3a(src, pack=_load_research_pack())
+    failures = [r for r in results if r.status is ResultStatus.PACK_VERB_FAILURE]
+    assert failures
+    s = _syms(session)
+    assert s["range-status"] == "mismatch"
+    assert s["range-divergence"] == "upper"


### PR DESCRIPTION
## Phase 2 Expressibility

Implements four independently-buildable Phase 2 items on top of v0.13.0 (PR #42, base commit `9380500`). Each phase is its own commit, tested before the next began.

### Phases completed

**D-1 — Composition parameter literals** (`9f707e2`)
Compositions accept a numeric or quoted-string literal as the single parameter argument, alongside the existing bare-name form. `CompositionCallNode.arg` is now `str | ASTNode | None`; every reader (parser, analyzer, interpreter, renderer) branches on the type. Quoted-string args always render with quotes to preserve round-trip integrity.

**D-4 — Deontic contradiction detection** (`bdd68e3`)
`detect_contradictions()` is a static, warning-only analyzer pass reporting direct same-field conflicts between `require`/`forbid` statements with simple conditions (the four-rule table from the design). Compound conditions and `permit` are out of scope. Wired into `run()` as a pre-pass that emits an informational `⚠` result before execution — never blocks, never sets `had_error`, never changes an existing result.

**D-8 — `range_check` execution type + `validate` pack verb** (`39edf02`)
Adds `RangeCheckExecution` (the seventh execution type) to the discriminated union, with adapter parsing/load-time validation, interpreter `_exec_pack_range_check` (extract two numbers per side, compare exactly, report `lower`/`upper`/`both`/`none` divergence), and analyzer validation mirroring `substring_check`. The research pack gains a `validate` verb over `window`-typed symbols. Mismatch and parse_error surface as `PACK_VERB_FAILURE` with all four outputs stored before the raise.

**D-7 — Timer-driven decay** (`060ea7c`)
The listener advances metabolic decay once per `tick`-named adapter update, calling the existing `tick_decay` after the normal handler cascade completes. The exact-name guard means no other adapter update triggers decay; `finish_requested` is honored after the decay pass.

### Files

**Modified:** `src/liminate/parser.py`, `src/liminate/interpreter.py`, `src/liminate/analyzer.py`, `src/liminate/renderer.py`, `src/liminate/vocabulary.py`, `src/liminate/adapter.py`, `src/liminate/run.py`, `src/liminate/listener.py`, `examples/pack_research.json`, `tests/test_parser.py` (one superseded reject-literal test updated to assert the new valid behavior)

**Created:** `tests/test_composition_param_literals.py` (16), `tests/test_contradiction_detection.py` (16), `tests/test_range_check.py` (15), `tests/test_decay_tick_adapter.py` (10)

### Tests

`python3 -m pytest tests/` → **1441 passed** (1384 baseline + 57 new), zero regressions.

### Invariants (§6) — all satisfied

1. `CompositionCallNode.arg` union handled in every reader.
2. Contradiction detection is additive — no existing result status, message, or test output changed.
3. `PackVerbExecution` union is exhaustive — the `RangeCheckExecution` branch is in the interpreter, analyzer, and adapter dispatch chains.
4. Decay fires only on `tick`-named updates (exact-name guard).
5. Pack contract backward compatibility — `pack_session.json` and `pack_research.json` still load and execute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)