### PR TITLE
feat: fit verb (conformance check) and iterable pack verbs (Phase 3 Spec 2)

### DIFF
--- a/benchmarks/_phase3_interpreter_bench.py
+++ b/benchmarks/_phase3_interpreter_bench.py
@@ -1,0 +1,148 @@
+"""Phase 3 §A0 benchmark harness — regression baseline for the four
+existing pack-verb execution types that the iterable-pack-verb refactor
+threads `current_item` through.
+
+Exercises:
+  B1 cite pass            -> substring_check  -> SUCCESS
+  B2 cite fail            -> substring_check  -> PACK_VERB_FAILURE substring_not_found
+  B3 verify mismatch      -> compare_values   -> PACK_VERB_FAILURE comparison_mismatch
+  B4 measure out of tol   -> numeric_extract  -> PACK_VERB_FAILURE outside_tolerance
+  B5 validate range diff  -> range_check      -> PACK_VERB_FAILURE range_mismatch
+
+Run from the repo root:  python3 benchmarks/_phase3_interpreter_bench.py
+Output is deterministic Markdown written to stdout.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from liminate.adapter import TestDomainPack, parse_pack_verb_signature  # noqa: E402
+from liminate.vocabulary import deactivate_all_pack_words  # noqa: E402
+
+from tests._v3a_helpers import run_v3a  # noqa: E402
+
+
+def _bench_pack() -> TestDomainPack:
+    """cite / verify / measure / validate over substring_check,
+    compare_values, numeric_extract_compare, range_check."""
+    vocab = [("claim", "noun"), ("source", "noun"), ("window", "noun")]
+    verbs = [
+        parse_pack_verb_signature({
+            "word": "cite",
+            "slots": [
+                {"name": "text", "connective": None, "required": True,
+                 "value_type": "value"},
+                {"name": "source", "connective": "from", "required": True,
+                 "value_type": "name", "type_constraint": "source"},
+            ],
+            "execution": {"type": "substring_check",
+                          "check_slot": "text", "against_slot": "source"},
+        }),
+        parse_pack_verb_signature({
+            "word": "verify",
+            "slots": [
+                {"name": "claim", "connective": None, "required": True,
+                 "value_type": "name", "type_constraint": "claim"},
+                {"name": "source", "connective": "from", "required": True,
+                 "value_type": "name", "type_constraint": "source"},
+            ],
+            "execution": {"type": "compare_values",
+                          "left_slot": "claim", "right_slot": "source",
+                          "comparison": "structural", "on_mismatch": "flag",
+                          "status_target": "verification-status",
+                          "details_target": "verification-divergences"},
+        }),
+        parse_pack_verb_signature({
+            "word": "measure",
+            "slots": [
+                {"name": "value", "connective": None, "required": True,
+                 "value_type": "value"},
+                {"name": "source", "connective": "from", "required": True,
+                 "value_type": "name", "type_constraint": "source"},
+                {"name": "tolerance", "connective": "within", "required": True,
+                 "value_type": "value"},
+            ],
+            "execution": {"type": "numeric_extract_compare",
+                          "check_slot": "value", "against_slot": "source",
+                          "tolerance_slot": "tolerance", "on_mismatch": "flag",
+                          "status_target": "measure-status",
+                          "matched_target": "measure-matched",
+                          "delta_target": "measure-delta"},
+        }),
+        parse_pack_verb_signature({
+            "word": "validate",
+            "slots": [
+                {"name": "claimed", "connective": None, "required": True,
+                 "value_type": "value"},
+                {"name": "reference", "connective": "from", "required": True,
+                 "value_type": "name", "type_constraint": "window"},
+            ],
+            "execution": {"type": "range_check",
+                          "check_slot": "claimed", "against_slot": "reference",
+                          "on_mismatch": "flag",
+                          "status_target": "range-status",
+                          "claimed_target": "range-claimed",
+                          "reference_target": "range-reference",
+                          "divergence_target": "range-divergence"},
+        }),
+    ]
+    return TestDomainPack(declarations=[], script=[], name="bench",
+                          vocabulary=vocab, verbs=verbs)
+
+
+CASES = [
+    ("B1", "cite pass", '''
+        remember a source called the-source with "revenue was 100"
+        cite "revenue" from the-source
+    '''),
+    ("B2", "cite fail", '''
+        remember a source called the-source with "revenue was 100"
+        cite "deficit" from the-source
+    '''),
+    ("B3", "verify structural mismatch", '''
+        remember a claim called the-claim with customer as "acme" and total as 100
+        remember a source called the-source with customer as "acme" and total as 200
+        verify the-claim from the-source
+    '''),
+    ("B4", "measure outside tolerance", '''
+        remember a source called the-source with "the closest figure is 150"
+        measure 100 from the-source within 1
+    '''),
+    ("B5", "validate range mismatch", '''
+        remember a window called the-window with "between 10 and 20"
+        validate "from 10 to 25" from the-window
+    '''),
+]
+
+
+def run() -> str:
+    lines = ["# Phase 3 Interpreter Benchmark — existing pack verbs",
+             "",
+             "Regression baseline for cite/verify/measure/validate. Each case "
+             "records the final pack-verb result's status, failure_type, and "
+             "message.", ""]
+    for cid, label, src in CASES:
+        deactivate_all_pack_words()
+        _, results = run_v3a(src, pack=_bench_pack())
+        last = results[-1]
+        meta = last.metadata or {}
+        ftype = meta.get("failure_type", "—")
+        lines.append(f"## {cid} — {label}")
+        lines.append(f"- status: `{last.status.name}`")
+        lines.append(f"- failure_type: `{ftype}`")
+        lines.append(f"- message: `{last.message or '—'}`")
+        lines.append("")
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    sys.stdout.write(run())

--- a/benchmarks/phase3-interpreter-post.md
+++ b/benchmarks/phase3-interpreter-post.md
@@ -1,0 +1,28 @@
+# Phase 3 Interpreter Benchmark — existing pack verbs
+
+Regression baseline for cite/verify/measure/validate. Each case records the final pack-verb result's status, failure_type, and message.
+
+## B1 — cite pass
+- status: `SUCCESS`
+- failure_type: `—`
+- message: `—`
+
+## B2 — cite fail
+- status: `PACK_VERB_FAILURE`
+- failure_type: `substring_not_found`
+- message: `The text 'deficit' was not found in 'the-source'. The source begins: 'revenue was 100'`
+
+## B3 — verify structural mismatch
+- status: `PACK_VERB_FAILURE`
+- failure_type: `comparison_mismatch`
+- message: `'the-claim' does not match 'the-source'. Status: mismatch.`
+
+## B4 — measure outside tolerance
+- status: `PACK_VERB_FAILURE`
+- failure_type: `outside_tolerance`
+- message: `Claimed 100 but closest value in 'the-source' is 150 (delta: 50, tolerance: 1).`
+
+## B5 — validate range mismatch
+- status: `PACK_VERB_FAILURE`
+- failure_type: `range_mismatch`
+- message: `Claimed range 10 to 25 does not match 'the-window' (10 to 20) — divergence: upper.`

--- a/benchmarks/phase3-interpreter-pre.md
+++ b/benchmarks/phase3-interpreter-pre.md
@@ -1,0 +1,28 @@
+# Phase 3 Interpreter Benchmark — existing pack verbs
+
+Regression baseline for cite/verify/measure/validate. Each case records the final pack-verb result's status, failure_type, and message.
+
+## B1 — cite pass
+- status: `SUCCESS`
+- failure_type: `—`
+- message: `—`
+
+## B2 — cite fail
+- status: `PACK_VERB_FAILURE`
+- failure_type: `substring_not_found`
+- message: `The text 'deficit' was not found in 'the-source'. The source begins: 'revenue was 100'`
+
+## B3 — verify structural mismatch
+- status: `PACK_VERB_FAILURE`
+- failure_type: `comparison_mismatch`
+- message: `'the-claim' does not match 'the-source'. Status: mismatch.`
+
+## B4 — measure outside tolerance
+- status: `PACK_VERB_FAILURE`
+- failure_type: `outside_tolerance`
+- message: `Claimed 100 but closest value in 'the-source' is 150 (delta: 50, tolerance: 1).`
+
+## B5 — validate range mismatch
+- status: `PACK_VERB_FAILURE`
+- failure_type: `range_mismatch`
+- message: `Claimed range 10 to 25 does not match 'the-window' (10 to 20) — divergence: upper.`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liminate"
-version = "0.13.0"
+version = "0.14.0"
 description = "A prose-as-syntax language designed from the human end."
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/src/liminate/adapter.py
+++ b/src/liminate/adapter.py
@@ -30,6 +30,7 @@ from typing import Any
 from .vocabulary import (
     AppendToListExecution,
     CompareValuesExecution,
+    ConformanceCheckExecution,
     NumericExtractCompareExecution,
     PackVerbExecution,
     PackVerbSignature,
@@ -261,10 +262,21 @@ def _parse_execution(exec_def: dict) -> PackVerbExecution:
             reference_target=exec_def["reference_target"],
             divergence_target=exec_def["divergence_target"],
         )
+    if exec_type == "conformance_check":
+        return ConformanceCheckExecution(
+            record_slot=exec_def["record_slot"],
+            shape_slot=exec_def["shape_slot"],
+            on_mismatch=exec_def.get("on_mismatch", "flag"),
+            status_target=exec_def["status_target"],
+            missing_target=exec_def["missing_target"],
+            type_mismatch_target=exec_def["type_mismatch_target"],
+            extra_target=exec_def["extra_target"],
+        )
     raise ValueError(
         f"Unknown execution type '{exec_type}'. "
         f"Supported: set_value, substring_check, append_to_list, "
-        f"set_field, compare_values, numeric_extract_compare, range_check."
+        f"set_field, compare_values, numeric_extract_compare, range_check, "
+        f"conformance_check."
     )
 
 
@@ -387,6 +399,24 @@ def _validate_pack_verb_signature(sig: PackVerbSignature) -> None:
         for field_name in (
             "status_target", "claimed_target",
             "reference_target", "divergence_target",
+        ):
+            v = getattr(execution, field_name)
+            if not isinstance(v, str) or not v:
+                raise ValueError(
+                    f"Pack verb '{word}': '{field_name}' must be a "
+                    f"non-empty string."
+                )
+
+    # conformance_check: extra validation.
+    if isinstance(execution, ConformanceCheckExecution):
+        if execution.on_mismatch not in ("error", "flag"):
+            raise ValueError(
+                f"Pack verb '{word}' uses unknown on_mismatch "
+                f"'{execution.on_mismatch}'. Use 'error' or 'flag'."
+            )
+        for field_name in (
+            "status_target", "missing_target",
+            "type_mismatch_target", "extra_target",
         ):
             v = getattr(execution, field_name)
             if not isinstance(v, str) or not v:

--- a/src/liminate/analyzer.py
+++ b/src/liminate/analyzer.py
@@ -92,6 +92,7 @@ from .result import LiminateResult, ResultStatus
 from .vocabulary import (
     AppendToListExecution,
     CompareValuesExecution,
+    ConformanceCheckExecution,
     NumericExtractCompareExecution,
     RangeCheckExecution,
     SetFieldExecution,
@@ -1703,6 +1704,12 @@ def _check_pack_verb(
         if slot.name not in node.slot_values:
             continue
         value_node = node.slot_values[slot.name]
+        if isinstance(value_node, EachPronoun):
+            # Phase 3 Spec 2 (iterable pack verbs): an `each` slot resolves
+            # to a different element each iteration, so it has no single
+            # static symbol to constrain. Iterator presence and element
+            # type are validated in the execution-specific check below.
+            continue
         if slot.type_constraint is None:
             # No type constraint — anything goes at this layer; execution
             # checks below may still resolve names.
@@ -1755,6 +1762,8 @@ def _check_pack_verb(
         _check_pack_numeric_extract(node, execution, symtab)
     elif isinstance(execution, RangeCheckExecution):
         _check_pack_range_check(node, execution, symtab)
+    elif isinstance(execution, ConformanceCheckExecution):
+        _check_pack_conformance(node, execution, symtab, iterator)
     # SetValueExecution: nothing further beyond type_constraint loop.
 
 
@@ -1953,6 +1962,63 @@ def _check_pack_range_check(
             )
     elif isinstance(check_node, FieldAccessNode):
         _check_field_access(check_node, symtab)
+
+
+def _check_pack_conformance(
+    node: PackVerbNode,
+    execution: ConformanceCheckExecution,
+    symtab: dict[str, SymbolEntry],
+    iterator: IteratorContext | None,
+) -> None:
+    """Phase 3 Spec 2 — `conformance_check` (fit) analyzer validation. The
+    shape slot must name a record (the template). The record slot must name
+    a record, or be the `each` pronoun inside an iterator over records."""
+    shape_node = node.slot_values.get(execution.shape_slot)
+    if not isinstance(shape_node, NameRef):
+        raise _SemanticError(
+            f"'{node.word}' expects a name for the shape."
+        )
+    if shape_node.name not in symtab:
+        raise _SemanticError(
+            f"I can't find '{shape_node.name}'. "
+            f"You might need to 'remember' it first."
+        )
+    shape_entry = symtab[shape_node.name]
+    if shape_entry.type != "record":
+        raise _SemanticError(
+            f"'{node.word} to' expects a record shape, but "
+            f"'{shape_node.name}' is {_singular(shape_entry.type)}."
+        )
+
+    record_node = node.slot_values.get(execution.record_slot)
+    if isinstance(record_node, EachPronoun):
+        # Iterable form: `each <list> ... fit each to <shape>`. The iterator
+        # must exist and range over records (element type = record).
+        if iterator is None:
+            raise _SemanticError(
+                f"'{node.word} each' can only be used inside an 'each' loop."
+            )
+        if iterator.record_schemas is None:
+            raise _SemanticError(
+                f"'{node.word} each' expects a list of records to check "
+                f"against the shape."
+            )
+        return
+    if not isinstance(record_node, NameRef):
+        raise _SemanticError(
+            f"'{node.word}' expects a name for the record."
+        )
+    if record_node.name not in symtab:
+        raise _SemanticError(
+            f"I can't find '{record_node.name}'. "
+            f"You might need to 'remember' it first."
+        )
+    record_entry = symtab[record_node.name]
+    if record_entry.type != "record":
+        raise _SemanticError(
+            f"'{node.word}' expects a record, but '{record_node.name}' is "
+            f"{_singular(record_entry.type)}."
+        )
 
 
 def _check_finish(

--- a/src/liminate/build.py
+++ b/src/liminate/build.py
@@ -435,6 +435,9 @@ _EXECUTION_TYPE_NAMES = {
     "AppendToListExecution": "append_to_list",
     "SetFieldExecution": "set_field",
     "CompareValuesExecution": "compare_values",
+    "NumericExtractCompareExecution": "numeric_extract_compare",
+    "RangeCheckExecution": "range_check",
+    "ConformanceCheckExecution": "conformance_check",
 }
 
 

--- a/src/liminate/interpreter.py
+++ b/src/liminate/interpreter.py
@@ -41,6 +41,7 @@ from .analyzer import SymbolEntry, analyze
 from .vocabulary import (
     AppendToListExecution,
     CompareValuesExecution,
+    ConformanceCheckExecution,
     DecayingValue,
     NumericExtractCompareExecution,
     RangeCheckExecution,
@@ -657,7 +658,7 @@ def _exec_op(
     if isinstance(node, CompositionCallNode):
         return _exec_composition_call(node, symtab)
     if isinstance(node, PackVerbNode):
-        return _exec_pack_verb(node, symtab)
+        return _exec_pack_verb(node, symtab, current_item)
     if isinstance(node, AddNode):
         return _exec_add(node, symtab, current_item)
     if isinstance(node, RemoveNode):
@@ -781,23 +782,34 @@ def _exec_remember_record(
 def _exec_pack_verb(
     node: PackVerbNode,
     symtab: dict[str, SymbolEntry],
+    current_item: Any = None,
 ) -> list[str]:
-    """v2 — dispatch by execution type via isinstance."""
+    """v2 — dispatch by execution type via isinstance.
+
+    `current_item` carries the per-element value when this pack verb runs
+    under an enclosing `each` (Phase 3 Spec 2 iterable pack verbs). It
+    defaults to None, so the non-`each` path is byte-identical to before —
+    an `each` slot resolves to `current_item` only via the EachPronoun
+    branch of `_evaluate_expression`."""
     execution = node.signature.execution
     if isinstance(execution, SetValueExecution):
-        return _exec_pack_set_value(node, execution, symtab)
+        return _exec_pack_set_value(node, execution, symtab, current_item)
     if isinstance(execution, SubstringCheckExecution):
-        return _exec_pack_substring_check(node, execution, symtab)
+        return _exec_pack_substring_check(node, execution, symtab, current_item)
     if isinstance(execution, AppendToListExecution):
-        return _exec_pack_append_to_list(node, execution, symtab)
+        return _exec_pack_append_to_list(node, execution, symtab, current_item)
     if isinstance(execution, SetFieldExecution):
-        return _exec_pack_set_field(node, execution, symtab)
+        return _exec_pack_set_field(node, execution, symtab, current_item)
     if isinstance(execution, CompareValuesExecution):
-        return _exec_pack_compare_values(node, execution, symtab)
+        return _exec_pack_compare_values(node, execution, symtab, current_item)
     if isinstance(execution, NumericExtractCompareExecution):
-        return _exec_pack_numeric_extract_compare(node, execution, symtab)
+        return _exec_pack_numeric_extract_compare(
+            node, execution, symtab, current_item
+        )
     if isinstance(execution, RangeCheckExecution):
-        return _exec_pack_range_check(node, execution, symtab)
+        return _exec_pack_range_check(node, execution, symtab, current_item)
+    if isinstance(execution, ConformanceCheckExecution):
+        return _exec_pack_fit(node, execution, symtab, current_item)
     raise _RuntimeError(
         f"Pack verb '{node.word}' has an unrecognized execution type."
     )
@@ -820,12 +832,13 @@ def _resolve_target(execution, node: PackVerbNode, symtab) -> str:
     return execution.target_name
 
 
-def _resolve_source(execution, node: PackVerbNode, symtab) -> Any:
+def _resolve_source(execution, node: PackVerbNode, symtab, current_item=None) -> Any:
     """v2 §8 — resolve the value to write. `source_slot` is evaluated via
-    `_evaluate_expression`; `literal_value` is returned as-is."""
+    `_evaluate_expression`; `literal_value` is returned as-is. `current_item`
+    is threaded so an `each` source slot resolves to the per-element value."""
     if execution.source_slot is not None:
         value_node = node.slot_values.get(execution.source_slot)
-        return _evaluate_expression(value_node, symtab, None)
+        return _evaluate_expression(value_node, symtab, current_item)
     return execution.literal_value
 
 
@@ -833,6 +846,7 @@ def _exec_pack_set_value(
     node: PackVerbNode,
     execution: SetValueExecution,
     symtab: dict[str, SymbolEntry],
+    current_item: Any = None,
 ) -> list[str]:
     """v2 §8 — set_value with name-vs-value special case preserved:
     when source_slot resolves to a NameRef, store the *name string* (so
@@ -844,7 +858,7 @@ def _exec_pack_set_value(
         if isinstance(value_node, NameRef):
             value: Any = value_node.name
         else:
-            value = _evaluate_expression(value_node, symtab, None)
+            value = _evaluate_expression(value_node, symtab, current_item)
     else:
         value = execution.literal_value
     _store(symtab, target_name, value)
@@ -855,13 +869,14 @@ def _exec_pack_substring_check(
     node: PackVerbNode,
     execution: SubstringCheckExecution,
     symtab: dict[str, SymbolEntry],
+    current_item: Any = None,
 ) -> list[str]:
     """v2 §4 — case-sensitive substring containment."""
     check_node = node.slot_values.get(execution.check_slot)
     against_node = node.slot_values.get(execution.against_slot)
-    check_raw = _evaluate_expression(check_node, symtab, None)
+    check_raw = _evaluate_expression(check_node, symtab, current_item)
     check_value = _format_scalar(check_raw)
-    against_value = _evaluate_expression(against_node, symtab, None)
+    against_value = _evaluate_expression(against_node, symtab, current_item)
     if not isinstance(against_value, str):
         against_value = _format_scalar(against_value)
     if check_value not in against_value:
@@ -888,10 +903,11 @@ def _exec_pack_append_to_list(
     node: PackVerbNode,
     execution: AppendToListExecution,
     symtab: dict[str, SymbolEntry],
+    current_item: Any = None,
 ) -> list[str]:
     """v2 §5 — deep-copy append to a list."""
     target_name = _resolve_target(execution, node, symtab)
-    resolved_value = _resolve_source(execution, node, symtab)
+    resolved_value = _resolve_source(execution, node, symtab, current_item)
     entry = symtab[target_name]
     # v1 §7 `none` placeholder seed pattern — clear the sentinel on first add.
     if (
@@ -911,10 +927,11 @@ def _exec_pack_set_field(
     node: PackVerbNode,
     execution: SetFieldExecution,
     symtab: dict[str, SymbolEntry],
+    current_item: Any = None,
 ) -> list[str]:
     """v2 §6 — set one field on a record. Creates the field if absent."""
     target_name = _resolve_target(execution, node, symtab)
-    resolved_value = _resolve_source(execution, node, symtab)
+    resolved_value = _resolve_source(execution, node, symtab, current_item)
     entry = symtab[target_name]
     entry.value[execution.field_name] = copy.deepcopy(resolved_value)
     if entry.schema is None:
@@ -927,13 +944,14 @@ def _exec_pack_compare_values(
     node: PackVerbNode,
     execution: CompareValuesExecution,
     symtab: dict[str, SymbolEntry],
+    current_item: Any = None,
 ) -> list[str]:
     """v2 §7 — compare two slot values; store status (and details for
     structural mode); raise on mismatch when on_mismatch == 'error'."""
     left_node = node.slot_values.get(execution.left_slot)
     right_node = node.slot_values.get(execution.right_slot)
-    left_value = _evaluate_expression(left_node, symtab, None)
-    right_value = _evaluate_expression(right_node, symtab, None)
+    left_value = _evaluate_expression(left_node, symtab, current_item)
+    right_value = _evaluate_expression(right_node, symtab, current_item)
     left_name = (
         left_node.name if isinstance(left_node, NameRef)
         else execution.left_slot
@@ -1010,6 +1028,7 @@ def _exec_pack_numeric_extract_compare(
     node: PackVerbNode,
     execution: NumericExtractCompareExecution,
     symtab: dict[str, SymbolEntry],
+    current_item: Any = None,
 ) -> list[str]:
     """Sixth execution type: extract all numbers from a source string,
     find the closest to the claimed value, check tolerance."""
@@ -1017,9 +1036,9 @@ def _exec_pack_numeric_extract_compare(
     against_node = node.slot_values.get(execution.against_slot)
     tolerance_node = node.slot_values.get(execution.tolerance_slot)
 
-    claimed = _evaluate_expression(check_node, symtab, None)
-    source_text = _evaluate_expression(against_node, symtab, None)
-    tolerance = _evaluate_expression(tolerance_node, symtab, None)
+    claimed = _evaluate_expression(check_node, symtab, current_item)
+    source_text = _evaluate_expression(against_node, symtab, current_item)
+    tolerance = _evaluate_expression(tolerance_node, symtab, current_item)
 
     if not isinstance(claimed, (int, float)):
         claimed = float(_format_scalar(claimed))
@@ -1107,6 +1126,7 @@ def _exec_pack_range_check(
     node: PackVerbNode,
     execution: RangeCheckExecution,
     symtab: dict[str, SymbolEntry],
+    current_item: Any = None,
 ) -> list[str]:
     """Seventh execution type (D-8): extract a (low, high) pair from a claimed
     range string and a reference window string, compare them exactly, and
@@ -1115,8 +1135,8 @@ def _exec_pack_range_check(
     check_node = node.slot_values.get(execution.check_slot)
     against_node = node.slot_values.get(execution.against_slot)
 
-    claimed_text = _evaluate_expression(check_node, symtab, None)
-    reference_text = _evaluate_expression(against_node, symtab, None)
+    claimed_text = _evaluate_expression(check_node, symtab, current_item)
+    reference_text = _evaluate_expression(against_node, symtab, current_item)
     if not isinstance(claimed_text, str):
         claimed_text = _format_scalar(claimed_text)
     if not isinstance(reference_text, str):
@@ -1188,6 +1208,93 @@ def _exec_pack_range_check(
                 "reference": reference_str,
                 "divergence": divergence,
                 "against_name": against_name,
+            },
+        )
+    return []
+
+
+def _pack_slot_display_name(value_node, slot_name: str) -> str:
+    """Friendly name for a pack-verb slot value in failure messages."""
+    if isinstance(value_node, NameRef):
+        return value_node.name
+    if isinstance(value_node, BareWord):
+        return value_node.word
+    if isinstance(value_node, EachPronoun):
+        return "each item"
+    return slot_name
+
+
+def _exec_pack_fit(
+    node: PackVerbNode,
+    execution: ConformanceCheckExecution,
+    symtab: dict[str, SymbolEntry],
+    current_item: Any = None,
+) -> list[str]:
+    """Eighth execution type (Phase 3 Spec 2): Level 2 conformance check —
+    `fit <record> to <shape>`. The shape is a template record; its field
+    names and inferred scalar types are the declared schema. A record
+    *fits* when every declared field is present with the matching scalar
+    type. Extra fields are collected but do NOT fail under Level 2.
+
+    All four outputs are stored to the symbol table BEFORE any raise
+    (handler-visibility pattern, matching range_check). A mismatch (a
+    missing field or a type mismatch) surfaces as PACK_VERB_FAILURE with
+    failure_type 'conformance_mismatch' — the load-bearing string the Spec 3
+    directive resolver keys on to emit `flag` rather than `block`.
+
+    A non-record on either slot is a usage error (ERROR_SEMANTIC via
+    _RuntimeError), NOT a conformance mismatch."""
+    record_node = node.slot_values.get(execution.record_slot)
+    shape_node = node.slot_values.get(execution.shape_slot)
+
+    record_value = _evaluate_expression(record_node, symtab, current_item)
+    shape_value = _evaluate_expression(shape_node, symtab, current_item)
+
+    record_name = _pack_slot_display_name(record_node, execution.record_slot)
+    shape_name = _pack_slot_display_name(shape_node, execution.shape_slot)
+
+    # Type guard: both operands must be records. A non-record is a usage
+    # error (ERROR_SEMANTIC), NOT a conformance mismatch.
+    if not isinstance(record_value, dict):
+        raise _RuntimeError(
+            f"'{node.word}' needs a record for '{record_name}', "
+            f"but it isn't a record."
+        )
+    if not isinstance(shape_value, dict):
+        raise _RuntimeError(
+            f"'{node.word}' needs a record shape for '{shape_name}', "
+            f"but it isn't a record."
+        )
+
+    # Level 2: every declared shape field must be present with the matching
+    # scalar type. Extras are collected but never penalized.
+    missing: list[str] = []
+    type_mismatch: list[str] = []
+    for field, shape_val in shape_value.items():
+        if field not in record_value:
+            missing.append(field)
+        elif _scalar_type(record_value[field]) != _scalar_type(shape_val):
+            type_mismatch.append(field)
+    extra = [f for f in record_value if f not in shape_value]
+
+    status = "mismatch" if (missing or type_mismatch) else "match"
+
+    # Handler-visibility: commit all four outputs before any raise.
+    _store(symtab, execution.status_target, status)
+    _store(symtab, execution.missing_target, list(missing))
+    _store(symtab, execution.type_mismatch_target, list(type_mismatch))
+    _store(symtab, execution.extra_target, list(extra))
+
+    if status == "mismatch":
+        raise _PackVerbFailure(
+            f"'{record_name}' does not fit the shape '{shape_name}'. "
+            f"Missing: {missing}. Type mismatches: {type_mismatch}.",
+            metadata={
+                "verb": node.word,
+                "failure_type": "conformance_mismatch",
+                "missing": list(missing),
+                "type_mismatch": list(type_mismatch),
+                "extra": list(extra),
             },
         )
     return []

--- a/src/liminate/parser.py
+++ b/src/liminate/parser.py
@@ -1676,6 +1676,20 @@ def _parse_pack_slot_value(
     if slot.value_type == "value":
         return _parse_value(stream)
     # "name" mode — UNKNOWN-only path.
+    # Phase 3 Spec 2 (iterable pack verbs): inside an `each` block, the
+    # `each` pronoun is a valid slot filler — it resolves to the current
+    # element during per-element execution. Mirrors the `transform`
+    # precedent in `_parse_atom`. Without the enclosing `each`, `each`
+    # falls through to the reserved-word rejection below.
+    peek = stream.peek()
+    if (
+        peek is not None
+        and peek.type is TokenType.VERB
+        and peek.value == "each"
+        and stream.in_clause("each")
+    ):
+        stream.consume()  # eat the `each` pronoun
+        return EachPronoun()
     value_tok = stream.consume()
     if value_tok is None:
         raise _ParseError(_pack_verb_missing_slot_error(sig, slot))
@@ -3130,7 +3144,9 @@ def _parse_atom(stream: TokenStream) -> ASTNode:
     # same way it acts as a pronoun inside a `where` condition (v1b §37).
     # It resolves to the current element during per-element evaluation.
     if tok.type is TokenType.VERB and tok.value == "each":
-        if stream.in_clause("transform"):
+        # Phase 3 Spec 2: a pack verb with a "value"-typed slot can also
+        # take `each` inside an enclosing `each` block (iterable pack verbs).
+        if stream.in_clause("transform") or stream.in_clause("each"):
             return EachPronoun()
         raise _ParseError(
             "'each' is a verb in Liminate — it iterates a list, or "

--- a/src/liminate/vocabulary.py
+++ b/src/liminate/vocabulary.py
@@ -404,6 +404,17 @@ class RangeCheckExecution:
     divergence_target: str   # symbol name for "lower" / "upper" / "both" / "none"
 
 
+@dataclass(frozen=True)
+class ConformanceCheckExecution:
+    record_slot: str            # positional slot: the record being checked
+    shape_slot: str             # the template record naming the shape
+    on_mismatch: str            # "error" | "flag" — follows the existing pattern
+    status_target: str          # stores "match" | "mismatch"
+    missing_target: str         # stores list of declared field names absent from the record
+    type_mismatch_target: str   # stores list of field names present but wrong-typed
+    extra_target: str           # stores list of field names in record not in shape
+
+
 PackVerbExecution = (
     SetValueExecution
     | SubstringCheckExecution
@@ -412,6 +423,7 @@ PackVerbExecution = (
     | CompareValuesExecution
     | NumericExtractCompareExecution
     | RangeCheckExecution
+    | ConformanceCheckExecution
 )
 
 

--- a/tests/test_conformance_fit.py
+++ b/tests/test_conformance_fit.py
@@ -1,0 +1,261 @@
+"""Phase 3 Spec 2 — the `conformance_check` execution type (`fit` verb) and
+iterable pack verbs (the `each` pronoun in pack-verb slots).
+
+`conformance_check` performs a Level 2 schema fit: every field declared by a
+shape template must be present in the record with the matching scalar type.
+Extra fields are collected but do NOT fail under Level 2. A mismatch surfaces
+as PACK_VERB_FAILURE with `failure_type == "conformance_mismatch"` — the
+load-bearing string the Spec 3 directive resolver keys on. A non-record on
+either slot is a usage error (ERROR_SEMANTIC), not a conformance mismatch.
+
+Iterable pack verbs: inside an `each` block, a pack verb's slot may be the
+`each` pronoun, resolving to the current element per iteration.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from liminate.adapter import TestDomainPack, parse_pack_verb_signature
+from liminate.result import ResultStatus
+from liminate.vocabulary import ConformanceCheckExecution
+
+from tests._v3a_helpers import run_v3a
+
+
+# ---------------------------------------------------------------------------
+# Pack construction — a `fit` verb over the conformance_check execution type.
+# ---------------------------------------------------------------------------
+
+
+_FIT_DEF = {
+    "word": "fit",
+    "slots": [
+        {"name": "record", "connective": None, "required": True,
+         "value_type": "name"},
+        {"name": "shape", "connective": "to", "required": True,
+         "value_type": "name"},
+    ],
+    "execution": {
+        "type": "conformance_check",
+        "record_slot": "record",
+        "shape_slot": "shape",
+        "on_mismatch": "flag",
+        "status_target": "fit-status",
+        "missing_target": "fit-missing",
+        "type_mismatch_target": "fit-type-mismatch",
+        "extra_target": "fit-extra",
+    },
+}
+
+
+def _fit_pack() -> TestDomainPack:
+    sig = parse_pack_verb_signature(json.loads(json.dumps(_FIT_DEF)))
+    return TestDomainPack(
+        declarations=[], script=[], name="fitpack",
+        vocabulary=[], verbs=[sig],
+    )
+
+
+# The shape template uses `none`/`0` placeholders (empty strings won't parse,
+# v2c §92): customer -> string, total -> number, status -> string.
+_SHAPE = (
+    "remember a shape called valid-order with "
+    "customer as none and total as 0 and status as none"
+)
+
+
+def _run(program: str):
+    return run_v3a(program, pack=_fit_pack())
+
+
+def _syms(session):
+    return {
+        k: session.symtab[k].value
+        for k in (
+            "fit-status", "fit-missing", "fit-type-mismatch", "fit-extra",
+        )
+        if k in session.symtab
+    }
+
+
+# ---------------------------------------------------------------------------
+# §A4 — parse + load-time validation
+# ---------------------------------------------------------------------------
+
+
+def test_conformance_check_parses_to_dataclass():
+    sig = parse_pack_verb_signature(json.loads(json.dumps(_FIT_DEF)))
+    assert isinstance(sig.execution, ConformanceCheckExecution)
+    assert sig.execution.record_slot == "record"
+    assert sig.execution.shape_slot == "shape"
+    assert sig.execution.on_mismatch == "flag"
+
+
+def test_conformance_check_missing_shape_slot_raises():
+    bad = json.loads(json.dumps(_FIT_DEF))
+    del bad["execution"]["shape_slot"]
+    with pytest.raises(KeyError):
+        parse_pack_verb_signature(bad)
+
+
+def test_conformance_check_bad_on_mismatch_rejected():
+    bad = json.loads(json.dumps(_FIT_DEF))
+    bad["execution"]["on_mismatch"] = "shrug"
+    with pytest.raises(ValueError, match="on_mismatch"):
+        parse_pack_verb_signature(bad)
+
+
+def test_conformance_check_empty_target_rejected():
+    bad = json.loads(json.dumps(_FIT_DEF))
+    bad["execution"]["missing_target"] = ""
+    with pytest.raises(ValueError, match="missing_target"):
+        parse_pack_verb_signature(bad)
+
+
+def test_conformance_check_default_on_mismatch_is_flag():
+    base = json.loads(json.dumps(_FIT_DEF))
+    del base["execution"]["on_mismatch"]
+    sig = parse_pack_verb_signature(base)
+    assert sig.execution.on_mismatch == "flag"
+
+
+# ---------------------------------------------------------------------------
+# §A5 — execution outcomes
+# ---------------------------------------------------------------------------
+
+
+def test_fit_conforming_record_succeeds():
+    session, results = _run(
+        _SHAPE + "\n"
+        'remember an order called o with customer as "acme" '
+        "and total as 100 and status as \"shipped\"\n"
+        "fit o to valid-order"
+    )
+    assert results[-1].status is ResultStatus.SUCCESS
+    syms = _syms(session)
+    assert syms["fit-status"] == "match"
+    assert syms["fit-missing"] == []
+    assert syms["fit-type-mismatch"] == []
+    assert syms["fit-extra"] == []
+
+
+def test_fit_missing_field_is_conformance_mismatch():
+    session, results = _run(
+        _SHAPE + "\n"
+        'remember an order called o with customer as "acme" and total as 100\n'
+        "fit o to valid-order"
+    )
+    last = results[-1]
+    assert last.status is ResultStatus.PACK_VERB_FAILURE
+    assert last.metadata["failure_type"] == "conformance_mismatch"
+    assert last.metadata["missing"] == ["status"]
+    assert last.metadata["type_mismatch"] == []
+    # Handler-visibility: outputs committed before the raise.
+    assert _syms(session)["fit-status"] == "mismatch"
+    assert _syms(session)["fit-missing"] == ["status"]
+
+
+def test_fit_wrong_typed_field_is_conformance_mismatch():
+    session, results = _run(
+        _SHAPE + "\n"
+        'remember an order called o with customer as 5 '
+        'and total as 100 and status as "shipped"\n'
+        "fit o to valid-order"
+    )
+    last = results[-1]
+    assert last.status is ResultStatus.PACK_VERB_FAILURE
+    assert last.metadata["failure_type"] == "conformance_mismatch"
+    assert last.metadata["type_mismatch"] == ["customer"]
+    assert last.metadata["missing"] == []
+
+
+def test_fit_extra_fields_only_succeeds_level_2():
+    session, results = _run(
+        _SHAPE + "\n"
+        'remember an order called o with customer as "a" and total as 1 '
+        'and status as "s" and note as "extra"\n'
+        "fit o to valid-order"
+    )
+    assert results[-1].status is ResultStatus.SUCCESS
+    syms = _syms(session)
+    assert syms["fit-status"] == "match"
+    # Extras are collected, not penalized.
+    assert syms["fit-extra"] == ["note"]
+
+
+def test_fit_non_record_is_error_semantic():
+    session, results = _run(
+        _SHAPE + "\n"
+        "remember a number called o with 5\n"
+        "fit o to valid-order"
+    )
+    assert results[-1].status is ResultStatus.ERROR_SEMANTIC
+    # NOT a conformance mismatch — no fit-status written.
+    assert "fit-status" not in session.symtab
+
+
+def test_fit_non_record_shape_is_error_semantic():
+    session, results = _run(
+        'remember a number called bad-shape with 5\n'
+        'remember an order called o with customer as "a"\n'
+        "fit o to bad-shape"
+    )
+    assert results[-1].status is ResultStatus.ERROR_SEMANTIC
+
+
+# ---------------------------------------------------------------------------
+# §A6 — iterable pack verbs (`fit each`)
+# ---------------------------------------------------------------------------
+
+
+def test_fit_each_all_conforming_succeeds():
+    session, results = _run(
+        _SHAPE + "\n"
+        'remember an order called oa with customer as "a" '
+        'and total as 1 and status as "s"\n'
+        'remember an order called ob with customer as "b" '
+        'and total as 2 and status as "t"\n'
+        "remember a list called line-items with oa and ob\n"
+        "each line-items fit each to valid-order"
+    )
+    assert all(r.status is ResultStatus.SUCCESS for r in results)
+
+
+def test_fit_each_surfaces_failing_element():
+    session, results = _run(
+        _SHAPE + "\n"
+        'remember an order called oa with customer as "a" '
+        'and total as 1 and status as "s"\n'
+        'remember an order called ob with customer as "b" and total as 2\n'
+        "remember a list called line-items with oa and ob\n"
+        "each line-items fit each to valid-order"
+    )
+    last = results[-1]
+    assert last.status is ResultStatus.PACK_VERB_FAILURE
+    assert last.metadata["failure_type"] == "conformance_mismatch"
+    assert last.metadata["missing"] == ["status"]
+
+
+def test_fit_each_outside_loop_rejected_by_analyzer():
+    # `fit each` with no enclosing `each` is a semantic error.
+    session, results = _run(
+        _SHAPE + "\n"
+        "fit each to valid-order"
+    )
+    # Parser rejects bare `each` outside an each-clause as a parse error.
+    assert results[-1].status in (
+        ResultStatus.ERROR_PARSE, ResultStatus.ERROR_SEMANTIC,
+    )
+
+
+def test_fit_each_over_scalar_list_rejected():
+    # Iterating a flat (non-record) list with `fit each` is a semantic error.
+    session, results = _run(
+        _SHAPE + "\n"
+        "remember a list called nums with 1 and 2\n"
+        "each nums fit each to valid-order"
+    )
+    assert results[-1].status is ResultStatus.ERROR_SEMANTIC


### PR DESCRIPTION
Implements **Phase 3 Spec 2 interpreter machinery**: the `fit` verb (conformance check, the 8th pack-verb execution type) and iterable pack verbs (the `each` pronoun in pack-verb slots). The session-pack `fit` *definition* lands separately in `liminate-dev` (PART B), after this wheel is released.

## Phases (A3–A7)

- **A3** — `ConformanceCheckExecution` dataclass added to `vocabulary.py` (modeled on `RangeCheckExecution`), wired into the `PackVerbExecution` union.
- **A4** — `conformance_check` branch in `adapter._parse_execution` + a validation block in `_validate_pack_verb_signature` (`on_mismatch ∈ {error, flag}`; four non-empty string targets). Import added.
- **A5** — `_exec_pack_fit` in `interpreter.py`. Level 2 fit: every declared shape field present with matching scalar type; extras collected but not penalized. All four outputs stored **before** any raise. Mismatch → `PACK_VERB_FAILURE` with `failure_type: "conformance_mismatch"`. Non-record on either slot → `ERROR_SEMANTIC` (usage error), not a mismatch.
- **A6** — iterable pack verbs:
  - `parser.py`: `each` recognized as a slot filler inside an `each` clause (both `"name"` and `"value"` slot paths), mirroring the `transform` precedent.
  - `analyzer.py`: `current_item`/iterator context threaded through `_check_pack_verb`; `EachPronoun` slots deferred (no single static symbol); new `_check_pack_conformance` validates the shape names a record and the record slot is a record or `each` over a list of records.
  - `interpreter.py`: `current_item` (default `None`) threaded through `_exec_pack_verb` and every `_exec_pack_*` helper, so an `each` slot resolves per-element via the existing `EachPronoun` path.
- **A7** — version bump `0.13.0 → 0.14.0`.

Also brings `build.py`'s `_EXECUTION_TYPE_NAMES` current: it was missing the already-shipped `numeric_extract_compare` and `range_check` (latent inspection-manifest bug) in addition to the new `conformance_check`.

## Files modified
`src/liminate/{vocabulary,adapter,parser,analyzer,interpreter,build}.py`, `pyproject.toml`.
## Files added
`tests/test_conformance_fit.py` (+15 tests), `benchmarks/{_phase3_interpreter_bench.py,phase3-interpreter-pre.md,phase3-interpreter-post.md}`.

## Invariants satisfied (§A8)
1. 58-word base vocabulary untouched (`fit` is a pack verb).
2. Interpreter purity holds — no `print`/`input`/file I/O added.
3. `failure_type` for `fit` is exactly `"conformance_mismatch"` (the Spec 3 contract).
4. Existing pack verbs behaviorally unchanged — the no-`each` path threads `current_item=None`, identical to before.
5. All four conformance outputs written before any raise (handler-visibility, matching `range_check`).

## Benchmark diff result (§A0 / §A10)
`phase3-interpreter-pre.md` vs `phase3-interpreter-post.md` for B1–B5 (cite pass, cite fail, verify structural mismatch, measure outside tolerance, validate range mismatch): **diff empty — byte-identical**. The iterable-pack-verb refactor leaves `cite`/`verify`/`measure`/`validate` output unchanged.

## Tests
`python3 -m pytest` → **1456 passed** (1441 baseline + 15 new).

## Note for PART B (§B4)
The build prompt's §B4 shape-template example `remember a valid-order with customer as none ...` omits the required `called` keyword and does **not** parse under the current core grammar (`remember <article>? <descriptor>* called <name> with <fields>`). PART B's `fit` session-verb acceptance should use `remember a <descriptor> called valid-order with ...`. Flagged here so it's resolved before PART B. The `fit` machinery itself is agnostic to how the record/shape were constructed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)