### PR TITLE
fix: lex negative number literals as NUMBER tokens

### DIFF
--- a/src/liminate/lexer.py
+++ b/src/liminate/lexer.py
@@ -65,7 +65,11 @@ from .vocabulary import (
 )
 
 _DECORATIVE = ",.?!"
-_NUMBER_RE = re.compile(r"^\d+(?:\.\d+)?$")
+# A NUMBER token is an optionally-negative integer or decimal. The leading
+# minus is part of the literal (e.g. `-3`, `-3.5`); a lone `-` or an internal
+# hyphen (`total-dollars`) is NOT a number. Subtraction uses the `minus` word
+# operator, not the `-` symbol, so this does not collide with arithmetic.
+_NUMBER_RE = re.compile(r"^-?\d+(?:\.\d+)?$")
 
 
 class LexError(Exception):

--- a/tests/test_arithmetic.py
+++ b/tests/test_arithmetic.py
@@ -315,3 +315,39 @@ def test_arithmetic_renders_canonically():
     rendered = render(ast)
     # Re-parsing the rendered form must produce the same AST.
     assert parse(tokenize(rendered)) == ast
+
+
+# ---------------------------------------------------------------------------
+# Negative number literals (regression: `-3` was lexed as text, so a number
+# remembered as `-3` failed numeric comparisons with "requires numbers, but
+# 't' is text"). The leading minus is now part of the NUMBER token.
+# ---------------------------------------------------------------------------
+
+
+def test_negative_number_literal_compares_as_number():
+    session, results = run_lines([
+        'remember a number called t with -3',
+        'choose if t is below 0: show "neg" otherwise show "pos"',
+    ])
+    for r in results:
+        assert r.status is ResultStatus.SUCCESS, r.message
+    assert results[-1].output == ["neg"]
+
+
+def test_negative_literal_on_condition_right_hand_side():
+    session, results = run_lines([
+        'remember a number called t with 5',
+        'choose if t is above -3: show "above" otherwise show "below"',
+    ])
+    for r in results:
+        assert r.status is ResultStatus.SUCCESS, r.message
+    assert results[-1].output == ["above"]
+
+
+def test_list_of_negative_numbers_is_numeric():
+    session, results = run_lines([
+        'remember a list called xs with -2 and 5 and -8',
+        'show xs',
+    ])
+    for r in results:
+        assert r.status is ResultStatus.SUCCESS, r.message

--- a/tests/test_descending_ranges.py
+++ b/tests/test_descending_ranges.py
@@ -117,11 +117,13 @@ def test_step_zero_is_parse_error():
 
 
 def test_step_negative_is_parse_error():
-    # Negative numbers are not NUMBER tokens, so this surfaces as
-    # "I expected a number after 'by'".
+    # `-2` is now a NUMBER token (negative literals are numbers), so this is
+    # caught by the explicit positivity check on the step, same as `by 0`:
+    # direction comes from from/to, never from a negative step.
     _, results = run_v3a("gather the x from 1 to 10 by -2")
     errors = [r for r in results if r.status is ResultStatus.ERROR_PARSE]
     assert errors, results
+    assert "positive" in errors[0].message
 
 
 def test_step_non_numeric_is_parse_error():

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -103,6 +103,36 @@ def test_malformed_number_is_unknown():
     assert tokenize("3.14.5")[0].type is TokenType.UNKNOWN
 
 
+# ---------- negative number literals ----------
+
+def test_negative_integer_recognized_as_number():
+    tok = tokenize("-3")[0]
+    assert tok.type is TokenType.NUMBER
+    assert tok.value == "-3"
+
+
+def test_negative_decimal_recognized_as_number():
+    tok = tokenize("-3.5")[0]
+    assert tok.type is TokenType.NUMBER
+    assert tok.value == "-3.5"
+
+
+def test_negative_number_inside_sentence():
+    # `remember a number called t with -3` — the value token is NUMBER.
+    assert tokenize("with -3")[1].type is TokenType.NUMBER
+
+
+def test_bare_minus_is_not_a_number():
+    # A lone `-` has no digits — it must NOT be a number (guard against
+    # over-matching the leading-minus rule).
+    assert tokenize("-")[0].type is TokenType.UNKNOWN
+
+
+def test_hyphenated_name_is_not_a_number():
+    # `total-dollars` is a name, not a negative number (the minus is internal).
+    assert tokenize("total-dollars")[0].type is TokenType.UNKNOWN
+
+
 # ---------- decorative punctuation stripping (§22 line 430) ----------
 
 def test_commas_stripped_from_words():


### PR DESCRIPTION
## Summary
Negative number literals (`-3`, `-3.5`, `-8`) were lexed as **text**, so any negative value was unusable as a number:

```
remember a number called t with -3
choose if t is below 0: ...   →  Error: 'below' requires numbers, but 't' is text.

remember a list called xs with -2 and 5 and -8   →  Error: A list can't mix text and numbers. '-2' is text but '5' is a number.
```

## Root cause
`src/liminate/lexer.py` — `_NUMBER_RE = ^\d+(?:\.\d+)?$` had no leading minus, so `-3` fell through to `TokenType.UNKNOWN`. Everything downstream was already sign-ready (`_parse_number` uses `int()`/`float()`; the interpreter's other number regexes already use `-?\d+`), so the lexer regex was the lone outlier.

## Fix
One change: `_NUMBER_RE = ^-?\d+(?:\.\d+)?$`.

- Subtraction uses the **`minus` word** operator, not the `-` symbol, so this doesn't collide with arithmetic (`5 minus 3` is unaffected; `5 - 3` was never valid).
- A lone `-` and internal hyphens (`total-dollars`, `make-tincture`) still lex as non-numbers — guard tests added.
- The one intentional negative-rejection — a negative `gather … by` step — is **preserved**: `-2` is now a NUMBER token and is caught by the existing explicit `step_val <= 0` "must be positive" check in `parser.py`, instead of relying on the lexer accident. `test_step_negative_is_parse_error` updated to assert the `"positive"` message.

## Tests
- 5 lexer tests (negative int/decimal recognized; in-sentence; bare `-` and hyphenated-name guards).
- 3 behavior regression tests (comparison, condition RHS literal, list of negatives).
- Watched them fail first (`'-3' is text`), then pass.
- **Full suite: 1456 → 1464, all green.** End-to-end verified via the CLI.

## Note for release
No version bump in this PR — patch-bumping `0.14.0` and any changelog/release of the interpreter (and re-pin in `liminate-dev`'s `requirements.txt`) is left as a release decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
