### PR TITLE
chore: pyproject keyword positioning cleanup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 authors = [
     { name = "R. Michael Thomas" }
 ]
-keywords = ["programming-language", "prose-as-syntax", "natural-language", "interpreter"]
+keywords = ["prose-as-syntax", "natural-language", "interpreter"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Education",


### PR DESCRIPTION
## Summary

- Removes `"programming-language"` from the `keywords` list in `pyproject.toml`. Liminate's locked public-surface terminology never describes the project as a "programming language" — it's a "prose-as-syntax language" — and this PyPI keyword was in tension with that positioning.
- The `Topic :: Software Development :: Interpreters` classifier already covers PyPI discovery/categorization, so removal costs no real discoverability. The keyword was redundant with it.
- `classifiers` and `version` are untouched — this is a single-line metadata edit.

**Note on file inventory:** the spec expected `pyproject.toml` at blob `3ac4528`; live main has it at `0b80941`. Diffed the two — the only change is the `version = "0.15.1"` → `"0.16.0"` bump from the most recent commit on main (unrelated wave). The `keywords` line and `classifiers` block are unchanged from what the spec inspected, so this proceeded as planned.

No version bump / release included here — release sequencing (ride the next publish vs. cut 0.16.1) is the architect's call.

## Test plan
- [x] One-line diff: only the `"programming-language"` entry removed; other three keywords preserved in order
- [x] `classifiers` and `version` confirmed unchanged in the diff
- [x] `rm -rf dist/ build-artifacts && python3 -m build` succeeds (sdist + wheel)
- [x] Built `PKG-INFO` confirmed: `programming-language` absent; `Keywords: prose-as-syntax,natural-language,interpreter` present

🤖 Generated with [Claude Code](https://claude.com/claude-code)