### PR TITLE
Fix _emit_string round-trip for number/date-shaped string values

### DIFF
--- a/src/liminate/renderer.py
+++ b/src/liminate/renderer.py
@@ -70,6 +70,7 @@ from .parser import (
     WhenNode,
 )
 from .vocabulary import ALL_RESERVED
+from .lexer import _DATE_RE, _NUMBER_RE
 
 
 # v3a §110: action lines inside a `when` block are indented by two spaces
@@ -623,10 +624,22 @@ def _emit_string(s: str) -> str:
         as a verb/connective/etc.), or
       - the value differs from its lowercased form (case would be lost
         because the lexer normalizes unquoted words; quoted content is
-        preserved verbatim).
+        preserved verbatim), or
+      - the value is number-shaped or date-shaped (bare form would
+        re-lex as a NUMBER or DATE token — a self-typing lexical shape —
+        instead of a string, per lexer._classify's resolution order;
+        _NUMBER_RE / _DATE_RE are imported from the lexer so this stays
+        in lockstep with the literal grammar it mirrors).
     `with status as active` stays bare; `with status as "Active"` keeps
-    its quotes.
+    its quotes; a string value `"2025-07-01"` or `"75"` now keeps its
+    quotes so it round-trips as a string, not a date/number.
     """
-    if " " in s or s in ALL_RESERVED or s != s.lower():
+    if (
+        " " in s
+        or s in ALL_RESERVED
+        or s != s.lower()
+        or _NUMBER_RE.match(s)
+        or _DATE_RE.match(s)
+    ):
         return f'"{s}"'
     return s

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -10,6 +10,8 @@ Verifies:
      round-trips through `parse_when_block` (split-by-indent).
 """
 
+from datetime import date
+
 import pytest
 
 from liminate.lexer import tokenize
@@ -20,6 +22,7 @@ from liminate.parser import (
     CompoundConditionNode,
     ConditionNode,
     CountNode,
+    DateLiteral,
     EachNode,
     EachPronoun,
     FilterNode,
@@ -39,7 +42,7 @@ from liminate.parser import (
     parse,
     parse_when_block,
 )
-from liminate.renderer import render, render_with_explicit_precedence
+from liminate.renderer import _emit_string, render, render_with_explicit_precedence
 from liminate.reorderer import reorder
 from liminate.result import LiminateResult, ResultStatus
 
@@ -77,6 +80,19 @@ def test_render_bareword_with_uppercase_keeps_quotes():
     """Same rule applies to BareWord nodes — if the stored value carries
     case that would be lost on re-lex, emit it quoted."""
     assert render(BareWord("Active")) == '"Active"'
+
+
+def test_emit_string_quotes_number_and_date_shaped_content():
+    """A string value whose content is number- or date-shaped must stay
+    quoted — bare emission would re-lex as a NUMBER/DATE token (the
+    lexer's self-typing lexical shapes), not a string. `-3.5` guards the
+    full _NUMBER_RE shape (sign + decimal), not just plain digits.
+    Safe bare strings (single lowercase non-reserved, non-numeric word)
+    are unaffected."""
+    assert _emit_string("2025-07-01") == '"2025-07-01"'
+    assert _emit_string("75") == '"75"'
+    assert _emit_string("-3.5") == '"-3.5"'
+    assert _emit_string("active") == "active"
 
 
 def test_render_show():
@@ -323,6 +339,12 @@ ROUND_TRIP_SENTENCES = [
     ),
     # `of` on the left side of a condition (v2d §100)
     ('choose if total of o1 is above 50: show "big order"', None),
+    # _emit_string round-trip gap: a string value shaped like a NUMBER or
+    # DATE literal must keep its quotes so it re-parses as a string, not
+    # a NumberLiteral/DateLiteral.
+    ('remember a value called d with "2025-07-01"', None),
+    ('remember a value called n with "75"', None),
+    ('remember a value called n with "-3.5"', None),
 ]
 
 
@@ -340,6 +362,64 @@ def test_round_trip(line, comps):
         f"round-trip mismatch:\n  original: {line!r}\n  canonical: {rendered!r}\n"
         f"  first AST: {first_ast}\n  second AST: {second_ast}"
     )
+
+
+# ---------- _emit_string round-trip gap: number/date-shaped strings ----------
+
+
+def test_date_shaped_string_value_round_trips_as_string_not_date_literal():
+    """A QuotedString whose content is date-shaped must stay a string
+    through render + re-parse, not collapse into a DateLiteral."""
+    line = 'remember a value called d with "2025-07-01"'
+    first_ast = _parse(line)
+    assert isinstance(first_ast, RememberValueNode)
+    assert isinstance(first_ast.value, QuotedString)
+
+    rendered = render(first_ast)
+    assert rendered == 'remember a value called d with "2025-07-01"'
+
+    second_ast = _parse(rendered)
+    assert isinstance(second_ast.value, QuotedString)
+    assert second_ast == first_ast
+
+
+def test_number_shaped_string_value_round_trips_as_string_not_number_literal():
+    """A QuotedString whose content is number-shaped must stay a string
+    through render + re-parse, not collapse into a NumberLiteral."""
+    line = 'remember a value called n with "75"'
+    first_ast = _parse(line)
+    assert isinstance(first_ast, RememberValueNode)
+    assert isinstance(first_ast.value, QuotedString)
+
+    rendered = render(first_ast)
+    assert rendered == 'remember a value called n with "75"'
+
+    second_ast = _parse(rendered)
+    assert isinstance(second_ast.value, QuotedString)
+    assert second_ast == first_ast
+
+
+def test_negative_decimal_number_shaped_string_value_stays_quoted():
+    """Guards the full _NUMBER_RE shape (leading '-' and a decimal
+    point), not just a plain-digits case."""
+    line = 'remember a value called n with "-3.5"'
+    first_ast = _parse(line)
+    assert isinstance(first_ast.value, QuotedString)
+
+    rendered = render(first_ast)
+    assert rendered == 'remember a value called n with "-3.5"'
+
+    second_ast = _parse(rendered)
+    assert second_ast == first_ast
+
+
+def test_real_number_and_date_literals_still_render_bare():
+    """Regression guard: this fix is confined to _emit_string (string
+    nodes). Genuine NumberLiteral/DateLiteral values must keep rendering
+    bare — the fix must not make real numbers/dates start quoting."""
+    assert render(NumberLiteral(75)) == "75"
+    assert render(NumberLiteral(-3.5)) == "-3.5"
+    assert render(DateLiteral(value=date(2025, 7, 1))) == "2025-07-01"
 
 
 # ---------- mixed-precedence amber still produces a canonical rendering ----------


### PR DESCRIPTION
## The defect

`renderer._emit_string(s)` decides whether a string value needs quotes to survive the round-trip property `parse(tokenize(render(ast))) == ast`. The previous rule quoted iff the value contained a space, matched a reserved word, or differed from its lowercased form.

That rule missed two self-typing lexical shapes. `lexer._classify` resolves a bare unquoted word as: reserved-word tables → `_NUMBER_RE` → `_DATE_RE` → `UNKNOWN`. So a **string** whose content is number-shaped or date-shaped, emitted bare, re-lexed as a `NUMBER` or `DATE` token — not a string:

- `_emit_string("2025-07-01")` → `2025-07-01` → re-lexes as `DATE` → parses to `DateLiteral`, not the original string.
- `_emit_string("75")` → `75` → re-lexes as `NUMBER` → parses to `NumberLiteral`.
- `_emit_string("-3.5")` → same break (full `_NUMBER_RE` shape: sign + decimal).

This is a Calendar-Era (v29) regression in kind: `_DATE_RE` was added to the lexer as a new self-typing shape, and `_emit_string` was never taught about it. The number case shares the root cause.

## The fix

Added one clause to `_emit_string`'s quoting condition: also quote when the value matches `_NUMBER_RE` or `_DATE_RE`.

**Import, not copy.** `_NUMBER_RE`/`_DATE_RE` are imported from `.lexer` rather than re-declared in `renderer.py` — mirroring the function's existing pattern of importing `ALL_RESERVED` from `vocabulary` instead of restating the reserved-word list. A local copy would create a second source of truth that must be updated in lockstep every time the lexer's literal grammar grows, which is exactly the failure that produced this bug. `lexer.py` imports only `re` and `vocabulary` (not `renderer`), so `renderer → lexer` is one-directional and adds no import cycle.

Out of scope (per the build spec): no rename of `_NUMBER_RE`/`_DATE_RE`, no changes to `lexer.py`, no changes to the `QuotedString`/`BareWord`/`RememberValueNode` `with`-vs-`from` routing logic (a separate, already-correct round-trip guard), no vocabulary or AST changes.

## Invariants confirmed

- `grep -nE 'compile\(r?["\x27]\^' src/liminate/renderer.py` → no matches (regex sourced only via import, not copied).
- `python3 -c "import liminate.renderer, liminate.lexer"` → imports cleanly, no circular import.
- `_emit_string('2025-07-01') → '"2025-07-01"'`, `_emit_string('75') → '"75"'`, `_emit_string('-3.5') → '"-3.5"'`, `_emit_string('active') → 'active'` (matches spec exactly).
- Real `NumberLiteral`/`DateLiteral` nodes still render bare (`_emit_string` is only reached from `BareWord`/`QuotedString` branches).

## Tests

Added to `tests/test_renderer.py`:
- Unit-level `_emit_string` quoting check for date/number-shaped content plus the negative/decimal shape.
- Three new round-trip cases in the existing `ROUND_TRIP_SENTENCES` parametrized suite.
- Explicit AST-level guards that a date/number-shaped `QuotedString` value stays a `QuotedString` through render + re-parse (not a `DateLiteral`/`NumberLiteral`).
- Regression guard that genuine `NumberLiteral`/`DateLiteral` nodes keep rendering bare.

`pytest tests/test_renderer.py -v` → 77 passed (8 new).
`pytest -q` (full suite) → **1845 passed**, no regressions.

## Release note

This warrants the dormant `0.16.1` publish (per the build spec) — the fix changes rendered output for a previously-broken case, so it needs a version bump to propagate. PyPI release remains the architect's manual gate; not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)